### PR TITLE
Adapt to latest opam (2.1.0~rc2)

### DIFF
--- a/opam
+++ b/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {build}
   "ocamlfind" {build}
   "cmdliner" {build & >= "1.0.0"}
-  "opam-client" {build & >= "2.0.0"}
+  "opam-client" {build & >= "2.1.0"}
 ]
 build: make
 dev-repo: "git+https://github.com/AltGr/opam-bundle"

--- a/shell/bootstrap.sh
+++ b/shell/bootstrap.sh
@@ -7,7 +7,8 @@ start
 title "Bootstrap: checking for prerequisites"
 
 # Avoid interference from an existing opam installation
-eval $(opam config revert-env) >/dev/null 2>&1 || true
+eval $(opam env --revert 2>/dev/null) >/dev/null 2>&1 || true
+unset OPAMSWITCH
 
 MISSING=
 check_prereq() {

--- a/shell/common.sh
+++ b/shell/common.sh
@@ -9,12 +9,15 @@ title() {
   printf "\n\033[33m================\033[m %-45s \033[33m================\033[m\n\n" "$*"
 }
 logged_cmd() {
+  local R=0
   printf "$1... "
   shift
   echo "+ [ $1 ] $*" >>$LOG
-  "$@" >>$LOG 2>&1
+  "$@" >>$LOG 2>&1 || R=$?
   echo >>$LOG
-  printf "\033[32mdone\033[m\n"
+  if [ $R -eq 0 ]; then printf "\033[32mdone\033[m\n"; return
+  else echo; return $R
+  fi
 }
 
 start() {

--- a/shell/configure.sh
+++ b/shell/configure.sh
@@ -17,29 +17,7 @@ else
       logged_cmd "Initialising" opam init --bare --no-setup --yes --disable-sandboxing $DIR/repo
    fi
    logged_cmd "Creating sandbox" opam switch create default ocaml-bootstrap
-   ln -sf "$PREFIX/lib/ocaml" "$(opam config var lib)/ocaml"
+   ln -sf "$PREFIX/lib/ocaml" "$(opam var lib)/ocaml"
 fi
 
-title "Configure: bootstrapping auxiliary utilities"
-
-echo "Output is in $LOG"
-logged_cmd "Compiling bootstrap utilities" opam install opam-depext --yes
-
-title "Configure: getting system dependencies"
-
-echo "You may be asked for 'sudo' access to install required system dependencies"
-echo "through your package system"
-echo
-if opam depext %{install_packages}%; then
-  touch has_depexts
-  finished
-else
-  REQUIRED=$(opam depext %{install_packages}% --list --short)
-  if [ -z "$REQUIRED" ]; then touch has_depexts; finished; exit 0; fi
-  echo "These required system dependencies could not be automatically installed:"
-  for p in $REQUIRED; do echo "  - $p"; done
-  echo
-  echo "Please install them and retry this script.";
-  finished
-  exit 1
-fi
+finished

--- a/src/opamBundleMain.ml
+++ b/src/opamBundleMain.ml
@@ -15,15 +15,13 @@ open OpamProcess.Job.Op
 
 let bootstrap_packages ocamlv = [
   OpamPackage.Name.of_string "ocaml-base-compiler", Some (`Eq, ocamlv);
-  OpamPackage.Name.of_string "opam-depext",
-  Some (`Geq, OpamPackage.Version.of_string "1.1.0");
 ]
 
 let system_ocaml_package_name = OpamPackage.Name.of_string "ocaml-system"
 
 let wrapper_ocaml_package_name = OpamPackage.Name.of_string "ocaml"
 
-let ocaml_config_package = OpamPackage.of_string "ocaml-config.1"
+let ocaml_config_package = OpamPackage.of_string "ocaml-config.2"
 
 (* This package will be created solely for the bundle, and replaces
    ocaml-system *)
@@ -65,6 +63,8 @@ let opam_archive_url opamv =
 
 let output_extension = "tar.gz"
 
+let stdlib_output = output
+
 let create_bundle ocamlv opamv repo debug output env test doc yes self_extract
     packages_targets =
   OpamClientConfig.opam_init
@@ -87,7 +87,7 @@ let create_bundle ocamlv opamv repo debug output env test doc yes self_extract
   in
   let opamv = match opamv with
     | Some v -> v
-    | None -> OpamPackage.Version.of_string "2.0.0~rc2"
+    | None -> OpamPackage.Version.of_string "2.1.0~rc2"
   in
   let output = match output, packages with
     | Some f, _ ->
@@ -153,7 +153,7 @@ let create_bundle ocamlv opamv repo debug output env test doc yes self_extract
   OpamFilename.with_tmp_dir @@ fun tmp ->
   let opam_root = OpamFilename.Op.(tmp / "root") in
   OpamStateConfig.update ~root_dir:opam_root ();
-  let repos_dir = OpamFilename.Op.(tmp / "repos") in
+  (* let repos_dir = OpamFilename.Op.(tmp / "repos") in *)
   (* *** *)
   OpamConsole.header_msg "Initialising repositories";
   let gen_repo_name repos_map base =
@@ -543,7 +543,6 @@ let create_bundle ocamlv opamv repo debug output env test doc yes self_extract
   OpamFilename.mkdir target_links;
   let repo_file =
     OpamFile.Repo.create
-      ~opam_version:OpamVersion.current_nopatch
       ~dl_cache:[cache_dirname]
       ()
   in
@@ -749,7 +748,7 @@ let create_bundle ocamlv opamv repo debug output env test doc yes self_extract
     let buf = Bytes.create sz in
     let rec copy () =
       let len = input ic buf 0 sz in
-      if len <> 0 then (Pervasives.output oc buf 0 len; copy ())
+      if len <> 0 then (stdlib_output oc buf 0 len; copy ())
     in
     copy ();
     close_in ic;


### PR DESCRIPTION
Lots of small adjustments for CLI and API changes;

Rework of the depexts handling stuff since it's now embedded in opam.
The current version works (with the downside of running the OS package-manager
commands in non-interactive mode), but it's quite the hack.
