### PR TITLE
Add tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,4 +33,6 @@ jobs:
 
       - run: opam install . --deps-only --with-test
       - run: opam exec -- make
-      - run: ./opam-bundle --help
+      - run: opam exec -- make stub-tests
+      - run: opam exec -- make real-tests
+        if: matrix.ocaml-compiler == '4.14.x'

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,16 @@ build:
 	dune build
 	cp _build/install/default/bin/opam-bundle .
 
+stub-tests:
+	dune build @runtest tests/stub
+
+real-tests:
+	dune build @runtest tests/real
+
+.PHONY: tests
+tests: stub-tests real-tests
+test: tests
+
 .PHONY: clean
 clean:
 	dune clean

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,3 @@
 (lang dune 2.7)
 (name opam-bundle)
+(cram enable)

--- a/opam-bundle.opam
+++ b/opam-bundle.opam
@@ -14,7 +14,7 @@ depends: [
   "cmdliner" {build & >= "1.1.0"}
   "opam-client" {build & >= "2.1.0"}
 ]
-build: [ "dune" "build" "-j" jobs "-p" name ]
+build: [ "dune" "build" "-j" jobs "-p" name "@runtest" {with-test} ]
 dev-repo: "git+https://github.com/AltGr/opam-bundle"
 flags: plugin
 synopsis: "A tool that creates stand-alone source bundles from opam packages"

--- a/shell/compile.sh
+++ b/shell/compile.sh
@@ -64,7 +64,7 @@ EOF
 chmod +x ${PREFIX}/bin/sudo
 
 R=0
-logged_cmd "Compiling packages" opam install --confirm=unsafe-yes %{install_packages}% %{doc?--with-doc:}% %{test?--with-test:}% || R=$?
+logged_cmd "Compiling packages" opam install --yes %{install_packages}% %{doc?--with-doc:}% %{test?--with-test:}% || R=$?
 
 rm -f ${PREFIX}/bin/sudo
 

--- a/tests/dune
+++ b/tests/dune
@@ -1,0 +1,3 @@
+(cram
+ (applies_to :whole_subtree)
+ (deps %{bin:opam-bundle}))

--- a/tests/real/odoc.t
+++ b/tests/real/odoc.t
@@ -1,0 +1,122 @@
+This test verify bundling of real package `odoc` with compiler version 4.02.3 and opam version 2.0.
+
+  $ export OPAMNOENVNOTICE=1
+  $ export OPAMYES=1
+  $ export OPAMROOT=$PWD/OPAMROOT
+  $ export OPAMSTATUSLINE=never
+  $ export OPAMVERBOSE=-1
+  $ opam --version
+  2.1.4
+  $ opam-bundle odoc --ocaml=4.02.3 --opam=2.0 --self --yes 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  No environment specified, will use the following for package resolution (based on the host system):
+    - arch = $ARCH
+    - os = $OS
+    - os-distribution = $OSDISTRIB
+    - os-version = $OSVERSION
+    - os-family = $OSFAMILLY
+  
+  <><> Initialising repositories ><><><><><><><><><><><><><><><><><><><><><><><><>
+  [opam.ocaml.org] Initialised
+  
+  <><> Resolving package set ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  [ERROR] No solution for odoc & ocaml-bootstrap.4.02.3:   * Incompatible packages:
+              - ocaml-bootstrap
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler < 3.08 -> ocaml < 4.02.3
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml < 4.02.3
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.03.0
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.04.0
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.04.1
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.04.2
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.05.0
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.06.0
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.06.1
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.07.0
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.07.1
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.08.0
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.08.1
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.09.0
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.09.1
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.10.0
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.10.1
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.10.2
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.11.0
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.11.1
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.11.2
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.12.0
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.12.1
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.13.0
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.13.1
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.14.0
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 4.14.1
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 5.0.0
+              no matching version
+            * Missing dependency:
+              - ocaml-bootstrap -> ocaml -> ocaml-config -> ocaml-base-compiler >= 3.08.0~ -> ocaml >= 5.01.0
+              no matching version
+  
+  
+  $ sh ./odoc-bundle.sh -y
+  sh: 0: cannot open ./odoc-bundle.sh: No such file
+  [2]
+  $ sh ./odoc-bundle/compile.sh ../ODOC
+  sh: 0: cannot open ./odoc-bundle/compile.sh: No such file
+  [2]
+  $ ODOC/bin/odoc
+  ODOC/bin/odoc: not found
+  [127]

--- a/tests/real/opam-bundle.t
+++ b/tests/real/opam-bundle.t
@@ -1,0 +1,72 @@
+This test verify bundling of real package `opam-bundle` of version 0.4.
+
+  $ export OPAMNOENVNOTICE=1
+  $ export OPAMYES=1
+  $ export OPAMROOT=$PWD/OPAMROOT
+  $ export OPAMSTATUSLINE=never
+  $ export OPAMVERBOSE=-1
+  $ opam --version
+  2.1.4
+  $ opam-bundle "opam-bundle@https://github.com/AltGr/opam-bundle/archive/refs/tags/0.4.tar.gz" opam-client.2.0.10 --self --opam=2.1 --ocaml=4.14.0 --yes 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  No environment specified, will use the following for package resolution (based on the host system):
+    - arch = $ARCH
+    - os = $OS
+    - os-distribution = $OSDISTRIB
+    - os-version = $OSVERSION
+    - os-family = $OSFAMILLY
+  
+  <><> Initialising repositories ><><><><><><><><><><><><><><><><><><><><><><><><>
+  [opam.ocaml.org] Initialised
+  
+  <><> Getting external packages ><><><><><><><><><><><><><><><><><><><><><><><><>
+  [NOTE] Will use package definition found in source for opam-bundle
+  
+  <><> Resolving package set ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  The following packages will be included:
+    - base-bigarray.base
+    - base-bytes.base
+    - base-threads.base
+    - base-unix.base
+    - cmdliner.1.2.0
+    - cppo.1.6.9
+    - cudf.0.10
+    - dose3.5.0.1-2
+    - dune.3.7.1
+    - extlib.1.7.7-1
+    - mccs.1.1+14
+    - ocaml.4.14.0
+    - ocaml-base-compiler.4.14.0
+    - ocaml-bootstrap.4.14.0
+    - ocaml-config.2
+    - ocaml-options-vanilla.1
+    - ocamlbuild.0.14.2
+    - ocamlfind.1.9.6
+    - ocamlgraph.2.0.0
+    - opam-bundle.0.4
+    - opam-client.2.0.10
+    - opam-core.2.0.10
+    - opam-file-format.2.1.6
+    - opam-format.2.0.10
+    - opam-repository.2.0.10
+    - opam-solver.2.0.10
+    - opam-state.2.0.10
+    - re.1.10.4
+    - seq.base
+    - stdlib-shims.0.3.0
+  The bundle will be installable on systems matching the following: os != "win32"
+  [NOTE] Opam system sandboxing (introduced in 2.0) will be disabled in the bundle. You need to trust that the build scripts of the included packages don't write outside of their build directory and dest dir.
+  Continue ? [Y/n] y
+  
+  <><> Getting all archives <><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  
+  <><> Getting bootstrap packages <><><><><><><><><><><><><><><><><><><><><><><><>
+  [ERROR] Opam archive at https://github.com/ocaml/opam/releases/download/2.1/opam-full-2.1.tar.gz could not be obtained: curl error code 404
+  $ sh ./opam-bundle-bundle.sh -y
+  sh: 0: cannot open ./opam-bundle-bundle.sh: No such file
+  [2]
+  $ sh ./opam-bundle-bundle/compile.sh ../BUNDLE
+  sh: 0: cannot open ./opam-bundle-bundle/compile.sh: No such file
+  [2]
+  $ BUNDLE/bin/opam-bundle
+  BUNDLE/bin/opam-bundle: not found
+  [127]

--- a/tests/stub/basic.t
+++ b/tests/stub/basic.t
@@ -1,0 +1,431 @@
+This test verify basic functionalities of `opam-bundle`. Every package used is a stub package.
+More complex tests on various options could be found in *stub* directory. Tests with real repositories
+and packages are under *complex* directory.
+
+Repo initial setup with two packages `foo` and `bar` that depends on `foo` and other required packages.
+  $ export OPAMNOENVNOTICE=1
+  $ export OPAMYES=1
+  $ export OPAMROOT=$PWD/OPAMROOT
+  $ export OPAMSTATUSLINE=never
+  $ export OPAMVERBOSE=-1
+  $ opam --version
+  2.1.4
+  $ cat > compile << EOF
+  > #!/bin/sh
+  > echo "I'm launching \$(basename \${0}) \$@!"
+  > EOF
+  $ chmod +x compile
+  $ tar czf compile.tar.gz compile
+  $ SHA=`openssl sha256 compile.tar.gz | cut -d ' ' -f 2`
+OCaml archive setup
+  $ mkdir ocaml-4.14.0
+  $ cat > ocaml-4.14.0/configure << EOF
+  > set -uex
+  > sed -i "s:PREFIX:\$2:g" Makefile
+  > echo "configured"
+  > EOF
+  $ chmod +x ocaml-4.14.0/configure
+  $ cat > ocaml-4.14.0/Makefile << EOF
+  > world:
+  > 	echo "make world"
+  > world.opt:
+  > 	echo "world opt"
+  > install:
+  > 	mkdir -p PREFIX/bin/
+  > 	cp ocaml PREFIX/bin/
+  > 	cp ocamlc PREFIX/bin/
+  > 	cp ocamlopt PREFIX/bin/
+  > 	cp $(which opam) PREFIX/bin/
+  > EOF
+  $ cat > ocaml-4.14.0/ocaml << EOF
+  > echo "I'm compiling \$1!"
+  > EOF
+  $ cp ocaml-4.14.0/ocaml ocaml-4.14.0/ocamlc
+  $ cp ocaml-4.14.0/ocaml ocaml-4.14.0/ocamlopt
+  $ tar czf ocaml.tar.gz ocaml-4.14.0
+  $ OCAMLSHA=`openssl sha256 ocaml.tar.gz | cut -d ' ' -f 2`
+Repo setup
+  $ mkdir -p REPO/packages/
+  $ cat > REPO/repo << EOF
+  > opam-version: "2.0"
+  > EOF
+Foo package.
+  $ mkdir -p REPO/packages/foo/foo.1
+  $ cat > REPO/packages/foo/foo.1/opam << EOF
+  > opam-version: "2.0"
+  > build: [ "sh" "compile" name ]
+  > install: [
+  >  [ "cp" "compile" "%{bin}%/%{name}%" ]
+  > ]
+  > url {
+  >  src: "file://./compile.tar.gz"
+  >  checksum: "sha256=$SHA"
+  > }
+  > EOF
+Bar package.
+  $ mkdir -p REPO/packages/bar/bar.1
+  $ cat > REPO/packages/bar/bar.1/opam << EOF
+  > opam-version: "2.0"
+  > build: [ "sh" "compile" name ]
+  > install: [
+  >  [ "cp" "compile" "%{bin}%/%{name}%" ]
+  > ]
+  > depends: [ "foo" ]
+  > url {
+  >  src: "file://./compile.tar.gz"
+  >  checksum: "sha256=$SHA"
+  > }
+  > EOF
+Ocaml-system.4.14.0 package.
+  $ mkdir -p REPO/packages/ocaml-system/ocaml-system.4.14.0
+  $ cat > REPO/packages/ocaml-system/ocaml-system.4.14.0/opam << EOF
+  > opam-version: "2.0"
+  > EOF
+Ocaml-config.2 package.
+  $ mkdir -p REPO/packages/ocaml-config/ocaml-config.2
+  $ cat > REPO/packages/ocaml-config/ocaml-config.2/opam << EOF
+  > opam-version: "2.0"
+  > EOF
+Ocaml.4.14.0 package.
+  $ mkdir -p REPO/packages/ocaml/ocaml.4.14.0
+  $ cat > REPO/packages/ocaml/ocaml.4.14.0/opam << EOF
+  > opam-version: "2.0"
+  > depends: [
+  >   ("ocaml-system" | "ocaml-base-compiler")
+  >   "ocaml-config"
+  > ]
+  > url {
+  >  src: "file://./compile.tar.gz"
+  >  checksum: "sha256=$SHA"
+  > }
+  > EOF
+Ocaml-base-compiler.4.14.0 package.
+  $ mkdir -p REPO/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0
+  $ cat > REPO/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/opam << EOF
+  > opam-version: "2.0"
+  > build: [ "sh" "compile" name ]
+  > install: [
+  >  [ "chmod" "+x" "compile" ]
+  >  [ "cp" "compile" "%{bin}%/ocaml" ]
+  > ]
+  > url {
+  >  src: "file://./ocaml.tar.gz"
+  >  checksum: "sha256=$OCAMLSHA"
+  > }
+  > EOF
+Opam setup
+  $ mkdir $OPAMROOT
+  $ opam init --bare ./REPO --no-setup --bypass-checks
+  No configuration file found, using built-in defaults.
+  
+  <><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
+  [default] Initialised
+  $ opam switch create one --empty
+
+
+
+Running opam-bundle with sanitized output that contains remplaced platform specific information.
+
+
+============================== Test 1 ==============================
+
+
+Bundle single package `foo`.
+
+  $ opam-bundle foo.1 --repository ./REPO --ocaml=4.14.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  No environment specified, will use the following for package resolution (based on the host system):
+    - arch = $ARCH
+    - os = $OS
+    - os-distribution = $OSDISTRIB
+    - os-version = $OSVERSION
+    - os-family = $OSFAMILLY
+  
+  <><> Initialising repositories ><><><><><><><><><><><><><><><><><><><><><><><><>
+  [home] Initialised
+  
+  <><> Resolving package set ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  The following packages will be included:
+    - foo.1
+    - ocaml-base-compiler.4.14.0
+    - ocaml-bootstrap.4.14.0
+  According to the packages' metadata, the bundle should be installable on any arch/OS.
+  [NOTE] Opam system sandboxing (introduced in 2.0) will be disabled in the bundle. You need to trust that the build scripts of the included packages don't write outside of their build directory and dest dir.
+  Continue ? [Y/n] y
+  
+  <><> Getting all archives <><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  
+  <><> Getting bootstrap packages <><><><><><><><><><><><><><><><><><><><><><><><>
+  
+  <><> Building bundle ><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  Done. Bundle generated as $TESTCASE_ROOT/foo-bundle.tar.gz
+  $ tar xvf foo-bundle.tar.gz | grep -v sha256 | sort
+  foo-bundle/
+  foo-bundle/bootstrap.sh
+  foo-bundle/common.sh
+  foo-bundle/compile.sh
+  foo-bundle/configure.sh
+  foo-bundle/opam-full-2.1.0-rc2.tar.gz
+  foo-bundle/repo/
+  foo-bundle/repo/archives/
+  foo-bundle/repo/archives/foo.1/
+  foo-bundle/repo/archives/foo.1/compile.tar.gz
+  foo-bundle/repo/archives/ocaml-base-compiler.4.14.0/
+  foo-bundle/repo/archives/ocaml-base-compiler.4.14.0/ocaml.tar.gz
+  foo-bundle/repo/cache/
+  foo-bundle/repo/packages/
+  foo-bundle/repo/packages/foo/
+  foo-bundle/repo/packages/foo/foo.1/
+  foo-bundle/repo/packages/foo/foo.1/opam
+  foo-bundle/repo/packages/ocaml-base-compiler/
+  foo-bundle/repo/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/
+  foo-bundle/repo/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/opam
+  foo-bundle/repo/packages/ocaml-bootstrap/
+  foo-bundle/repo/packages/ocaml-bootstrap/ocaml-bootstrap.4.14.0/
+  foo-bundle/repo/packages/ocaml-bootstrap/ocaml-bootstrap.4.14.0/opam
+  foo-bundle/repo/repo
+  $ sh ./foo-bundle/compile.sh
+  This bundle will compile the application to $TESTCASE_ROOT/foo-bundle, WITHOUT installing
+  wrappers anywhere else.
+  
+  Press enter to continue... 
+  ================ Bootstrap: checking for prerequisites         ================
+  
+  Checking for cc... found
+  Checking for make... found
+  Checking for wget curl... found
+  Checking for patch... found
+  Checking for unzip... found
+  Checking for bunzip2... found
+  Checking for rsync... found
+  
+  ================ Bootstrap: compiling OCaml                    ================
+  
+  This may take a while. Output is in $TESTCASE_ROOT/foo-bundle/bootstrap.log
+  Uncompressing... done
+  Configuring... done
+  Compiling... done
+  Installing to temp prefix... done
+  Already compiled opam found
+  
+  ================ Configure: initialising opam                  ================
+  
+  Output is in $TESTCASE_ROOT/foo-bundle/configure.log
+  Initialising... done
+  Creating sandbox... done
+  
+  ================ Compile: installing packages                  ================
+  
+  Output is in $TESTCASE_ROOT/foo-bundle/compile.log
+  Compiling packages... done
+  Cleaning up... done
+  
+  All compiled within $TESTCASE_ROOT/foo-bundle. To use the compiled packages:
+  
+    - either re-run ./foo-bundle/compile.sh with a PREFIX argument to install command wrappers
+      (it won't recompile everything)
+  
+    - or run the following to update the environment in the current shell, so that
+      they are in your PATH:
+        export PATH="$TESTCASE_ROOT/foo-bundle/bootstrap/bin:$PATH"; eval $(opam env --root "$TESTCASE_ROOT/foo-bundle/opam" --set-root)
+  
+  $ opam exec --root ./foo-bundle/opam -- foo
+  I'm launching foo !
+
+
+============================== Test 2 ==============================
+
+
+Bundle package `bar` that depends on `foo`.
+
+  $ opam-bundle bar.1 --repository ./REPO --ocaml=4.14.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  No environment specified, will use the following for package resolution (based on the host system):
+    - arch = $ARCH
+    - os = $OS
+    - os-distribution = $OSDISTRIB
+    - os-version = $OSVERSION
+    - os-family = $OSFAMILLY
+  
+  <><> Initialising repositories ><><><><><><><><><><><><><><><><><><><><><><><><>
+  [home] Initialised
+  
+  <><> Resolving package set ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  The following packages will be included:
+    - bar.1
+    - foo.1
+    - ocaml-base-compiler.4.14.0
+    - ocaml-bootstrap.4.14.0
+  According to the packages' metadata, the bundle should be installable on any arch/OS.
+  [NOTE] Opam system sandboxing (introduced in 2.0) will be disabled in the bundle. You need to trust that the build scripts of the included packages don't write outside of their build directory and dest dir.
+  Continue ? [Y/n] y
+  
+  <><> Getting all archives <><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  
+  <><> Getting bootstrap packages <><><><><><><><><><><><><><><><><><><><><><><><>
+  
+  <><> Building bundle ><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  Done. Bundle generated as $TESTCASE_ROOT/bar-bundle.tar.gz
+  $ tar xvf bar-bundle.tar.gz | grep -v sha256 | sort
+  bar-bundle/
+  bar-bundle/bootstrap.sh
+  bar-bundle/common.sh
+  bar-bundle/compile.sh
+  bar-bundle/configure.sh
+  bar-bundle/opam-full-2.1.0-rc2.tar.gz
+  bar-bundle/repo/
+  bar-bundle/repo/archives/
+  bar-bundle/repo/archives/bar.1/
+  bar-bundle/repo/archives/bar.1/compile.tar.gz
+  bar-bundle/repo/archives/foo.1/
+  bar-bundle/repo/archives/foo.1/compile.tar.gz
+  bar-bundle/repo/archives/ocaml-base-compiler.4.14.0/
+  bar-bundle/repo/archives/ocaml-base-compiler.4.14.0/ocaml.tar.gz
+  bar-bundle/repo/cache/
+  bar-bundle/repo/packages/
+  bar-bundle/repo/packages/bar/
+  bar-bundle/repo/packages/bar/bar.1/
+  bar-bundle/repo/packages/bar/bar.1/opam
+  bar-bundle/repo/packages/foo/
+  bar-bundle/repo/packages/foo/foo.1/
+  bar-bundle/repo/packages/foo/foo.1/opam
+  bar-bundle/repo/packages/ocaml-base-compiler/
+  bar-bundle/repo/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/
+  bar-bundle/repo/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/opam
+  bar-bundle/repo/packages/ocaml-bootstrap/
+  bar-bundle/repo/packages/ocaml-bootstrap/ocaml-bootstrap.4.14.0/
+  bar-bundle/repo/packages/ocaml-bootstrap/ocaml-bootstrap.4.14.0/opam
+  bar-bundle/repo/repo
+  $ sh ./bar-bundle/compile.sh ../BAR
+  This bundle will compile the application to $TESTCASE_ROOT/bar-bundle, and put wrappers into
+  ../BAR/bin. You will need to retain $TESTCASE_ROOT/bar-bundle for the wrappers to work.
+  
+  Press enter to continue... 
+  ================ Bootstrap: checking for prerequisites         ================
+  
+  Checking for cc... found
+  Checking for make... found
+  Checking for wget curl... found
+  Checking for patch... found
+  Checking for unzip... found
+  Checking for bunzip2... found
+  Checking for rsync... found
+  
+  ================ Bootstrap: compiling OCaml                    ================
+  
+  This may take a while. Output is in $TESTCASE_ROOT/bar-bundle/bootstrap.log
+  Uncompressing... done
+  Configuring... done
+  Compiling... done
+  Installing to temp prefix... done
+  Already compiled opam found
+  
+  ================ Configure: initialising opam                  ================
+  
+  Output is in $TESTCASE_ROOT/bar-bundle/configure.log
+  Initialising... done
+  Creating sandbox... done
+  
+  ================ Compile: installing packages                  ================
+  
+  Output is in $TESTCASE_ROOT/bar-bundle/compile.log
+  Compiling packages... done
+  Cleaning up... done
+  Wrapper bar installed successfully.
+  $ opam exec --root ./bar-bundle/opam -- bar
+  I'm launching bar !
+  $ opam exec --root ./bar-bundle/opam -- foo
+  I'm launching foo !
+  $ find BAR | sort
+  BAR
+  BAR/bin
+  BAR/bin/bar
+  $ BAR/bin/bar
+  I'm launching bar !
+
+Cleaning up
+  $ rm -r BAR bar-bundle bar-bundle.tar.gz
+
+
+
+============================== Test 3 ==============================
+
+
+Bundle package `bar` that depends on `foo` with self-extracting script.
+
+  $ opam-bundle bar.1 --self --repository ./REPO --ocaml=4.14.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  No environment specified, will use the following for package resolution (based on the host system):
+    - arch = $ARCH
+    - os = $OS
+    - os-distribution = $OSDISTRIB
+    - os-version = $OSVERSION
+    - os-family = $OSFAMILLY
+  
+  <><> Initialising repositories ><><><><><><><><><><><><><><><><><><><><><><><><>
+  [home] Initialised
+  
+  <><> Resolving package set ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  The following packages will be included:
+    - bar.1
+    - foo.1
+    - ocaml-base-compiler.4.14.0
+    - ocaml-bootstrap.4.14.0
+  According to the packages' metadata, the bundle should be installable on any arch/OS.
+  [NOTE] Opam system sandboxing (introduced in 2.0) will be disabled in the bundle. You need to trust that the build scripts of the included packages don't write outside of their build directory and dest dir.
+  Continue ? [Y/n] y
+  
+  <><> Getting all archives <><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  
+  <><> Getting bootstrap packages <><><><><><><><><><><><><><><><><><><><><><><><>
+  
+  <><> Building bundle ><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  Done. Bundle generated as $TESTCASE_ROOT/bar-bundle.tar.gz
+  Self-extracting archive generated as $TESTCASE_ROOT/bar-bundle.sh
+
+  $ sh ./bar-bundle.sh -y
+  This bundle will compile the application to $TESTCASE_ROOT/bar-bundle, WITHOUT installing
+  wrappers anywhere else.
+  
+  ================ Bootstrap: checking for prerequisites         ================
+  
+  Checking for cc... found
+  Checking for make... found
+  Checking for wget curl... found
+  Checking for patch... found
+  Checking for unzip... found
+  Checking for bunzip2... found
+  Checking for rsync... found
+  
+  ================ Bootstrap: compiling OCaml                    ================
+  
+  This may take a while. Output is in $TESTCASE_ROOT/bar-bundle/bootstrap.log
+  Uncompressing... done
+  Configuring... done
+  Compiling... done
+  Installing to temp prefix... done
+  Already compiled opam found
+  
+  ================ Configure: initialising opam                  ================
+  
+  Output is in $TESTCASE_ROOT/bar-bundle/configure.log
+  Initialising... done
+  Creating sandbox... done
+  
+  ================ Compile: installing packages                  ================
+  
+  Output is in $TESTCASE_ROOT/bar-bundle/compile.log
+  Compiling packages... done
+  Cleaning up... done
+  
+  All compiled within $TESTCASE_ROOT/bar-bundle. To use the compiled packages:
+  
+    - either re-run bar-bundle/compile.sh with a PREFIX argument to install command wrappers
+      (it won't recompile everything)
+  
+    - or run the following to update the environment in the current shell, so that
+      they are in your PATH:
+        export PATH="$TESTCASE_ROOT/bar-bundle/bootstrap/bin:$PATH"; eval $(opam env --root "$TESTCASE_ROOT/bar-bundle/opam" --set-root)
+  
+
+  $ opam exec --root ./bar-bundle/opam -- bar
+  I'm launching bar !
+  $ opam exec --root ./bar-bundle/opam -- foo
+  I'm launching foo !

--- a/tests/stub/env.t
+++ b/tests/stub/env.t
@@ -1,0 +1,395 @@
+This test verify different environment specifications that could be used with `opam-bundle`.
+Every package used is a stub package.
+
+Repo initial setup with three packages `foo`, `bar`, and `baz`, with specific availabilities
+  $ export OPAMNOENVNOTICE=1
+  $ export OPAMYES=1
+  $ export OPAMROOT=$PWD/OPAMROOT
+  $ export OPAMSTATUSLINE=never
+  $ export OPAMVERBOSE=-1
+  $ opam --version
+  2.1.4
+Stub executable
+  $ cat > compile << EOF
+  > #!/bin/sh
+  > echo "I'm launching \$(basename \${0}) \$@!"
+  > EOF
+  $ chmod +x compile
+  $ tar czf compile.tar.gz compile
+  $ SHA=`openssl sha256 compile.tar.gz | cut -d ' ' -f 2`
+OCaml archive setup
+  $ mkdir ocaml-4.14.0
+  $ cat > ocaml-4.14.0/configure << EOF
+  > set -uex
+  > sed -i "s:PREFIX:\$2:g" Makefile
+  > echo "configured"
+  > EOF
+  $ chmod +x ocaml-4.14.0/configure
+  $ cat > ocaml-4.14.0/Makefile << EOF
+  > world:
+  > 	echo "make world"
+  > world.opt:
+  > 	echo "world opt"
+  > install:
+  > 	mkdir -p PREFIX/bin/
+  > 	cp ocaml PREFIX/bin/
+  > 	cp ocamlc PREFIX/bin/
+  > 	cp ocamlopt PREFIX/bin/
+  > 	cp $(which opam) PREFIX/bin/
+  > EOF
+  $ cat > ocaml-4.14.0/ocaml << EOF
+  > echo "I'm compiling \$1!"
+  > EOF
+  $ cp ocaml-4.14.0/ocaml ocaml-4.14.0/ocamlc
+  $ cp ocaml-4.14.0/ocaml ocaml-4.14.0/ocamlopt
+  $ tar czf ocaml.tar.gz ocaml-4.14.0
+  $ OCAMLSHA=`openssl sha256 ocaml.tar.gz | cut -d ' ' -f 2`
+Repo setup
+  $ mkdir -p REPO/packages/
+  $ cat > REPO/repo << EOF
+  > opam-version: "2.0"
+  > EOF
+=== Foo package (not available on linux) ===
+  $ mkdir -p REPO/packages/foo/foo.1
+  $ cat > REPO/packages/foo/foo.1/opam << EOF
+  > opam-version: "2.0"
+  > version: "1"
+  > available: (os != "linux")
+  > build: [ "sh" "compile" name ]
+  > install: [
+  >  [ "cp" "compile" "%{bin}%/%{name}%" ]
+  > ]
+  > depends : [
+  >  "ocaml" {>= "4.12.0"}
+  > ]
+  > url {
+  >  src: "file://./compile.tar.gz"
+  >  checksum: "sha256=$SHA"
+  > }
+  > EOF
+=== Bar package (not available on cygwin) ===
+  $ mkdir -p REPO/packages/bar/bar.1
+  $ cat > REPO/packages/bar/bar.1/opam << EOF
+  > opam-version: "2.0"
+  > version: "1"
+  > available: (os != "cygwin")
+  > build: [ "sh" "compile" name ]
+  > install: [
+  >  [ "cp" "compile" "%{bin}%/%{name}%" ]
+  > ]
+  > depends : [
+  >  "ocaml" {>= "4.14.0"}
+  > ]
+  > url {
+  >  src: "file://./compile.tar.gz"
+  >  checksum: "sha256=$SHA"
+  > }
+  > EOF
+=== Baz packages (available on both) ===
+  $ mkdir -p REPO/packages/baz/baz.1
+  $ cat > REPO/packages/baz/baz.1/opam << EOF
+  > opam-version: "2.0"
+  > version: "1"
+  > build: [ "sh" "compile" name ]
+  > install: [
+  >  [ "cp" "compile" "%{bin}%/%{name}%" ]
+  > ]
+  > depends : [
+  >  "ocaml" {>= "4.14.0"}
+  >  "foo" { os != "linux" }
+  >  "bar" { os != "cygwin" }
+  > ]
+  > url {
+  >  src: "file://./compile.tar.gz"
+  >  checksum: "sha256=$SHA"
+  > }
+  > EOF
+Ocaml-system.4.14.0 package.
+  $ mkdir -p REPO/packages/ocaml-system/ocaml-system.4.14.0
+  $ cat > REPO/packages/ocaml-system/ocaml-system.4.14.0/opam << EOF
+  > opam-version: "2.0"
+  > EOF
+Ocaml-config.2 package.
+  $ mkdir -p REPO/packages/ocaml-config/ocaml-config.2
+  $ cat > REPO/packages/ocaml-config/ocaml-config.2/opam << EOF
+  > opam-version: "2.0"
+  > EOF
+Ocaml.4.14.0 package.
+  $ mkdir -p REPO/packages/ocaml/ocaml.4.14.0
+  $ cat > REPO/packages/ocaml/ocaml.4.14.0/opam << EOF
+  > opam-version: "2.0"
+  > depends: [
+  >   ("ocaml-system" | "ocaml-base-compiler")
+  >   "ocaml-config"
+  > ]
+  > url {
+  >  src: "file://./compile.tar.gz"
+  >  checksum: "sha256=$SHA"
+  > }
+  > EOF
+Ocaml-base-compiler.4.14.0 package.
+  $ mkdir -p REPO/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0
+  $ cat > REPO/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/opam << EOF
+  > opam-version: "2.0"
+  > build: [ "sh" "compile" name ]
+  > install: [
+  >  [ "chmod" "+x" "compile" ]
+  >  [ "cp" "compile" "%{bin}%/ocaml" ]
+  > ]
+  > url {
+  >  src: "file://./ocaml.tar.gz"
+  >  checksum: "sha256=$OCAMLSHA"
+  > }
+  > EOF
+Opam setup
+  $ mkdir $OPAMROOT
+  $ opam init --bare ./REPO --no-setup --bypass-checks
+  No configuration file found, using built-in defaults.
+  
+  <><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
+  [default] Initialised
+  $ opam switch create one --empty
+
+
+
+Running opam-bundle with sanitized output that contains replaced platform specific information.
+
+
+============================== Test 1 ==============================
+
+
+Bundle package `baz`, without '--environment' option. That should lookup current platform (that should be linux), and filter packages in dependencies that
+are available on linux os (`foo` not included).
+
+  $ opam-bundle baz --repository ./REPO --ocaml=4.14.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  No environment specified, will use the following for package resolution (based on the host system):
+    - arch = $ARCH
+    - os = $OS
+    - os-distribution = $OSDISTRIB
+    - os-version = $OSVERSION
+    - os-family = $OSFAMILLY
+  
+  <><> Initialising repositories ><><><><><><><><><><><><><><><><><><><><><><><><>
+  [home] Initialised
+  
+  <><> Resolving package set ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  The following packages will be included:
+    - bar.1
+    - baz.1
+    - ocaml.4.14.0
+    - ocaml-base-compiler.4.14.0
+    - ocaml-bootstrap.4.14.0
+    - ocaml-config.2
+  The bundle will be installable on systems matching the following: os != "cygwin"
+  [NOTE] Opam system sandboxing (introduced in 2.0) will be disabled in the bundle. You need to trust that the build scripts of the included packages don't write outside of their build directory and dest dir.
+  Continue ? [Y/n] y
+  
+  <><> Getting all archives <><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  
+  <><> Getting bootstrap packages <><><><><><><><><><><><><><><><><><><><><><><><>
+  
+  <><> Building bundle ><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  Done. Bundle generated as $TESTCASE_ROOT/baz-bundle.tar.gz
+  $ tar --list -f baz-bundle.tar.gz | grep -v sha256 | sort
+  baz-bundle/
+  baz-bundle/bootstrap.sh
+  baz-bundle/common.sh
+  baz-bundle/compile.sh
+  baz-bundle/configure.sh
+  baz-bundle/opam-full-2.1.0-rc2.tar.gz
+  baz-bundle/repo/
+  baz-bundle/repo/archives/
+  baz-bundle/repo/archives/bar.1/
+  baz-bundle/repo/archives/bar.1/compile.tar.gz
+  baz-bundle/repo/archives/baz.1/
+  baz-bundle/repo/archives/baz.1/compile.tar.gz
+  baz-bundle/repo/archives/ocaml-base-compiler.4.14.0/
+  baz-bundle/repo/archives/ocaml-base-compiler.4.14.0/ocaml.tar.gz
+  baz-bundle/repo/archives/ocaml.4.14.0/
+  baz-bundle/repo/archives/ocaml.4.14.0/compile.tar.gz
+  baz-bundle/repo/cache/
+  baz-bundle/repo/packages/
+  baz-bundle/repo/packages/bar/
+  baz-bundle/repo/packages/bar/bar.1/
+  baz-bundle/repo/packages/bar/bar.1/opam
+  baz-bundle/repo/packages/baz/
+  baz-bundle/repo/packages/baz/baz.1/
+  baz-bundle/repo/packages/baz/baz.1/opam
+  baz-bundle/repo/packages/ocaml-base-compiler/
+  baz-bundle/repo/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/
+  baz-bundle/repo/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/opam
+  baz-bundle/repo/packages/ocaml-bootstrap/
+  baz-bundle/repo/packages/ocaml-bootstrap/ocaml-bootstrap.4.14.0/
+  baz-bundle/repo/packages/ocaml-bootstrap/ocaml-bootstrap.4.14.0/opam
+  baz-bundle/repo/packages/ocaml-config/
+  baz-bundle/repo/packages/ocaml-config/ocaml-config.2/
+  baz-bundle/repo/packages/ocaml-config/ocaml-config.2/opam
+  baz-bundle/repo/packages/ocaml/
+  baz-bundle/repo/packages/ocaml/ocaml.4.14.0/
+  baz-bundle/repo/packages/ocaml/ocaml.4.14.0/opam
+  baz-bundle/repo/repo
+
+Cleaning up
+  $ rm baz-bundle.tar.gz
+
+
+
+============================== Test 2 ==============================
+
+
+Bundle package `baz`, with os="cygwin" constraint specified in '--environment' option. That should filter packages in dependencies that
+are available on cygwin os (`bar` not included).
+
+  $ opam-bundle baz --environment os="cygwin" --repository ./REPO --ocaml=4.14.0 -y 2>&1
+  
+  <><> Initialising repositories ><><><><><><><><><><><><><><><><><><><><><><><><>
+  [home] Initialised
+  
+  <><> Resolving package set ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  The following packages will be included:
+    - baz.1
+    - foo.1
+    - ocaml.4.14.0
+    - ocaml-base-compiler.4.14.0
+    - ocaml-bootstrap.4.14.0
+    - ocaml-config.2
+  The bundle will be installable on systems matching the following: os != "linux"
+  [NOTE] Opam system sandboxing (introduced in 2.0) will be disabled in the bundle. You need to trust that the build scripts of the included packages don't write outside of their build directory and dest dir.
+  Continue ? [Y/n] y
+  
+  <><> Getting all archives <><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  
+  <><> Getting bootstrap packages <><><><><><><><><><><><><><><><><><><><><><><><>
+  
+  <><> Building bundle ><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  Done. Bundle generated as $TESTCASE_ROOT/baz-bundle.tar.gz
+
+
+  $ tar --list -f baz-bundle.tar.gz | grep -v sha256 | sort
+  baz-bundle/
+  baz-bundle/bootstrap.sh
+  baz-bundle/common.sh
+  baz-bundle/compile.sh
+  baz-bundle/configure.sh
+  baz-bundle/opam-full-2.1.0-rc2.tar.gz
+  baz-bundle/repo/
+  baz-bundle/repo/archives/
+  baz-bundle/repo/archives/baz.1/
+  baz-bundle/repo/archives/baz.1/compile.tar.gz
+  baz-bundle/repo/archives/foo.1/
+  baz-bundle/repo/archives/foo.1/compile.tar.gz
+  baz-bundle/repo/archives/ocaml-base-compiler.4.14.0/
+  baz-bundle/repo/archives/ocaml-base-compiler.4.14.0/ocaml.tar.gz
+  baz-bundle/repo/archives/ocaml.4.14.0/
+  baz-bundle/repo/archives/ocaml.4.14.0/compile.tar.gz
+  baz-bundle/repo/cache/
+  baz-bundle/repo/packages/
+  baz-bundle/repo/packages/baz/
+  baz-bundle/repo/packages/baz/baz.1/
+  baz-bundle/repo/packages/baz/baz.1/opam
+  baz-bundle/repo/packages/foo/
+  baz-bundle/repo/packages/foo/foo.1/
+  baz-bundle/repo/packages/foo/foo.1/opam
+  baz-bundle/repo/packages/ocaml-base-compiler/
+  baz-bundle/repo/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/
+  baz-bundle/repo/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/opam
+  baz-bundle/repo/packages/ocaml-bootstrap/
+  baz-bundle/repo/packages/ocaml-bootstrap/ocaml-bootstrap.4.14.0/
+  baz-bundle/repo/packages/ocaml-bootstrap/ocaml-bootstrap.4.14.0/opam
+  baz-bundle/repo/packages/ocaml-config/
+  baz-bundle/repo/packages/ocaml-config/ocaml-config.2/
+  baz-bundle/repo/packages/ocaml-config/ocaml-config.2/opam
+  baz-bundle/repo/packages/ocaml/
+  baz-bundle/repo/packages/ocaml/ocaml.4.14.0/
+  baz-bundle/repo/packages/ocaml/ocaml.4.14.0/opam
+  baz-bundle/repo/repo
+
+Cleaning up
+  $ rm baz-bundle.tar.gz
+
+
+
+============================== Test 3 ==============================
+
+
+Bundle package `baz`, with empty constraint specified in '--environment' option. That shouldn't filter any packages (considering 'any' constraint) and install
+all dependencies.
+
+  $ opam-bundle baz --environment --repository ./REPO --ocaml=4.14.0 -y 2>&1
+  
+  <><> Initialising repositories ><><><><><><><><><><><><><><><><><><><><><><><><>
+  [home] Initialised
+  
+  <><> Resolving package set ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  The following packages will be included:
+    - baz.1
+    - ocaml.4.14.0
+    - ocaml-base-compiler.4.14.0
+    - ocaml-bootstrap.4.14.0
+    - ocaml-config.2
+  According to the packages' metadata, the bundle should be installable on any arch/OS.
+  [NOTE] Opam system sandboxing (introduced in 2.0) will be disabled in the bundle. You need to trust that the build scripts of the included packages don't write outside of their build directory and dest dir.
+  Continue ? [Y/n] y
+  
+  <><> Getting all archives <><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  
+  <><> Getting bootstrap packages <><><><><><><><><><><><><><><><><><><><><><><><>
+  
+  <><> Building bundle ><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  Done. Bundle generated as $TESTCASE_ROOT/baz-bundle.tar.gz
+
+
+  $ tar --list -f baz-bundle.tar.gz | grep -v sha256 | sort
+  baz-bundle/
+  baz-bundle/bootstrap.sh
+  baz-bundle/common.sh
+  baz-bundle/compile.sh
+  baz-bundle/configure.sh
+  baz-bundle/opam-full-2.1.0-rc2.tar.gz
+  baz-bundle/repo/
+  baz-bundle/repo/archives/
+  baz-bundle/repo/archives/baz.1/
+  baz-bundle/repo/archives/baz.1/compile.tar.gz
+  baz-bundle/repo/archives/ocaml-base-compiler.4.14.0/
+  baz-bundle/repo/archives/ocaml-base-compiler.4.14.0/ocaml.tar.gz
+  baz-bundle/repo/archives/ocaml.4.14.0/
+  baz-bundle/repo/archives/ocaml.4.14.0/compile.tar.gz
+  baz-bundle/repo/cache/
+  baz-bundle/repo/packages/
+  baz-bundle/repo/packages/baz/
+  baz-bundle/repo/packages/baz/baz.1/
+  baz-bundle/repo/packages/baz/baz.1/opam
+  baz-bundle/repo/packages/ocaml-base-compiler/
+  baz-bundle/repo/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/
+  baz-bundle/repo/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/opam
+  baz-bundle/repo/packages/ocaml-bootstrap/
+  baz-bundle/repo/packages/ocaml-bootstrap/ocaml-bootstrap.4.14.0/
+  baz-bundle/repo/packages/ocaml-bootstrap/ocaml-bootstrap.4.14.0/opam
+  baz-bundle/repo/packages/ocaml-config/
+  baz-bundle/repo/packages/ocaml-config/ocaml-config.2/
+  baz-bundle/repo/packages/ocaml-config/ocaml-config.2/opam
+  baz-bundle/repo/packages/ocaml/
+  baz-bundle/repo/packages/ocaml/ocaml.4.14.0/
+  baz-bundle/repo/packages/ocaml/ocaml.4.14.0/opam
+  baz-bundle/repo/repo
+
+Cleaning up
+  $ rm baz-bundle.tar.gz
+
+
+
+============================== Test 4 (fail) ==============================
+
+Trying bundle package `bar` on cygwin. That will fail, since this package isn't available on cygwin.
+
+
+  $ opam-bundle bar --environment os="cygwin" --repository ./REPO --ocaml=4.14.0 -y 2>&1
+  
+  <><> Initialising repositories ><><><><><><><><><><><><><><><><><><><><><><><><>
+  [home] Initialised
+  
+  <><> Resolving package set ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  [ERROR] The following packages do not exist in the specified repositories, or are not available with the given configuration:
+            - bar: unmet availability conditions: 'os != "cygwin"'
+  
+  [5]

--- a/tests/stub/packages.t
+++ b/tests/stub/packages.t
@@ -1,0 +1,616 @@
+This test verify different package specifications that could be used with `opam-bundle`.
+Every package used is a stub package.
+
+  $ export OPAMNOENVNOTICE=1
+  $ export OPAMYES=1
+  $ export OPAMROOT=$PWD/OPAMROOT
+  $ export OPAMSTATUSLINE=never
+  $ export OPAMVERBOSE=-1
+  $ opam --version
+  2.1.4
+Different version of one stub executable
+  $ cat > compile << EOF
+  > #!/bin/sh
+  > echo "I'm launching \$(basename \${0}) \$@!"
+  > EOF
+  $ chmod +x compile
+  $ tar czf compile.tar.gz compile
+  $ SHA=`openssl sha256 compile.tar.gz | cut -d ' ' -f 2`
+  $ cat > compile1 << EOF
+  > #!/bin/sh
+  > echo "I'm launching \$(basename \${0}) v.1 \$@!"
+  > EOF
+  $ chmod +x compile1
+  $ tar czf compile1.tar.gz compile1
+  $ SHA1=`openssl sha256 compile1.tar.gz | cut -d ' ' -f 2`
+  $ cat > compile2 << EOF
+  > #!/bin/sh
+  > echo "I'm launching \$(basename \${0}) v.2 \$@!"
+  > EOF
+  $ chmod +x compile2
+  $ tar czf compile2.tar.gz compile2
+  $ SHA2=`openssl sha256 compile2.tar.gz | cut -d ' ' -f 2`
+  $ cat > compile3 << EOF
+  > #!/bin/sh
+  > echo "I'm launching \$(basename \${0}) v.3 \$@!"
+  > EOF
+  $ chmod +x compile3
+  $ tar czf compile3.tar.gz compile3
+  $ SHA3=`openssl sha256 compile3.tar.gz | cut -d ' ' -f 2`
+  $ cat > compile4 << EOF
+  > #!/bin/sh
+  > echo "I'm launching \$(basename \${0}) v.4 \$@!"
+  > EOF
+  $ chmod +x compile4
+OCaml archive setup
+  $ mkdir ocaml-4.14.0
+  $ cat > ocaml-4.14.0/configure << EOF
+  > set -uex
+  > sed -i "s:PREFIX:\$2:g" Makefile
+  > echo "configured"
+  > EOF
+  $ chmod +x ocaml-4.14.0/configure
+  $ cat > ocaml-4.14.0/Makefile << EOF
+  > world:
+  > 	echo "make world"
+  > world.opt:
+  > 	echo "world opt"
+  > install:
+  > 	mkdir -p PREFIX/bin/
+  > 	cp ocaml PREFIX/bin/
+  > 	cp ocamlc PREFIX/bin/
+  > 	cp ocamlopt PREFIX/bin/
+  > 	cp $(which opam) PREFIX/bin/
+  > EOF
+  $ cat > ocaml-4.14.0/ocaml << EOF
+  > echo "I'm compiling \$1!"
+  > EOF
+  $ cp ocaml-4.14.0/ocaml ocaml-4.14.0/ocamlc
+  $ cp ocaml-4.14.0/ocaml ocaml-4.14.0/ocamlopt
+  $ tar czf ocaml.tar.gz ocaml-4.14.0
+  $ OCAMLSHA=`openssl sha256 ocaml.tar.gz | cut -d ' ' -f 2`
+Repo setup
+  $ mkdir -p REPO/packages/
+  $ cat > REPO/repo << EOF
+  > opam-version: "2.0"
+  > EOF
+=== Foo packages ===
+Package which isn't included in repository.
+  $ mkdir foo.4
+  $ cat > foo.4/test.patch << EOF
+  > --- foo.4/compile4
+  > +++ foo.4/compile4
+  > @@ -1 +1 @@
+  > -echo "I'm launching \$(basename \${0}) v.4 \$@!"
+  > +echo "I'm launching with patch \$(basename \${0}) v.4 \$@!"
+  > EOF
+  $ cat > foo.4/opam << EOF
+  > opam-version: "2.0"
+  > version: "4"
+  > build: [ "sh" "compile4" name ]
+  > install: [
+  >  [ "cp" "compile4" "%{bin}%/%{name}%" ]
+  > ]
+  > depends : [
+  >  "ocaml" {>= "4.14.0"}
+  > ]
+  > extra-source "repo" {
+  >  src: "file://./REPO/repo"
+  > }
+  > patches : ["test.patch"]
+  > EOF
+  $ cp compile4 foo.4/
+Repository packages
+  $ mkdir -p REPO/packages/foo/foo.1 REPO/packages/foo/foo.2 REPO/packages/foo/foo.3
+  $ cat > REPO/packages/foo/foo.1/opam << EOF
+  > opam-version: "2.0"
+  > version: "1"
+  > build: [ "sh" "compile1" name ]
+  > install: [
+  >  [ "cp" "compile1" "%{bin}%/%{name}%" ]
+  > ]
+  > depends : [
+  >  "ocaml" {>= "4.12.0"}
+  > ]
+  > url {
+  >  src: "file://./compile1.tar.gz"
+  >  checksum: "sha256=$SHA1"
+  > }
+  > EOF
+  $ cat > REPO/packages/foo/foo.2/opam << EOF
+  > opam-version: "2.0"
+  > version: "2"
+  > build: [ "sh" "compile2" name ]
+  > install: [
+  >  [ "cp" "compile2" "%{bin}%/%{name}%" ]
+  > ]
+  > depends : [
+  >  "ocaml" {>= "4.13.0"}
+  > ]
+  > url {
+  >  src: "file://./compile2.tar.gz"
+  >  checksum: "sha256=$SHA2"
+  > }
+  > EOF
+  $ cat > REPO/packages/foo/foo.3/opam << EOF
+  > opam-version: "2.0"
+  > version: "3"
+  > build: [ "sh" "compile3" name ]
+  > install: [
+  >  [ "cp" "compile3" "%{bin}%/%{name}%" ]
+  > ]
+  > depends : [
+  >  "ocaml" {>= "4.14.0"}
+  > ]
+  > url {
+  >  src: "file://./compile3.tar.gz"
+  >  checksum: "sha256=$SHA3"
+  > }
+  > EOF
+Bar packages.
+  $ mkdir -p REPO/packages/bar/bar.1 REPO/packages/bar/bar.2 REPO/packages/bar/bar.3/files
+  $ cat > REPO/packages/bar/bar.1/opam << EOF
+  > opam-version: "2.0"
+  > version: "1"
+  > build: [ "sh" "compile1" name ]
+  > install: [
+  >  [ "cp" "compile1" "%{bin}%/%{name}%" ]
+  > ]
+  > depends : [
+  >  "ocaml" {>= "4.14.0"}
+  >  "foo" {= "1"}
+  > ]
+  > url {
+  >  src: "file://./compile1.tar.gz"
+  >  checksum: "sha256=$SHA1"
+  > }
+  > EOF
+  $ cat > REPO/packages/bar/bar.2/opam << EOF
+  > opam-version: "2.0"
+  > version: "2"
+  > build: [ "sh" "compile2" name ]
+  > install: [
+  >  [ "cp" "compile2" "%{bin}%/%{name}%" ]
+  > ]
+  > depends : [
+  >  "ocaml" {>= "4.14.0"}
+  >  "foo" {<= "2"}
+  > ]
+  > url {
+  >  src: "file://./compile2.tar.gz"
+  >  checksum: "sha256=$SHA2"
+  > }
+  > EOF
+  $ cat > REPO/packages/bar/bar.3/files/test.patch << EOF
+  > --- bar/compile3
+  > +++ bar/compile3
+  > @@ -1 +1 @@
+  > -echo "I'm launching \$(basename \${0}) v.3 \$@!"
+  > +echo "I'm launching with patch \$(basename \${0}) v.3 \$@!"
+  > EOF
+  $ cat > REPO/packages/bar/bar.3/opam << EOF
+  > opam-version: "2.0"
+  > version: "3"
+  > build: [ "sh" "compile3" name ]
+  > install: [
+  >  [ "cp" "compile3" "%{bin}%/%{name}%" ]
+  > ]
+  > depends : [
+  >  "ocaml" {>= "4.14.0"}
+  >  "foo" {>= "3"}
+  > ]
+  > patches : ["test.patch"]
+  > url {
+  >  src: "file://./compile3.tar.gz"
+  >  checksum: "sha256=$SHA3"
+  > }
+  > EOF
+Ocaml-system.4.14.0 package.
+  $ mkdir -p REPO/packages/ocaml-system/ocaml-system.4.14.0
+  $ cat > REPO/packages/ocaml-system/ocaml-system.4.14.0/opam << EOF
+  > opam-version: "2.0"
+  > EOF
+Ocaml-config.2 package.
+  $ mkdir -p REPO/packages/ocaml-config/ocaml-config.2
+  $ cat > REPO/packages/ocaml-config/ocaml-config.2/opam << EOF
+  > opam-version: "2.0"
+  > EOF
+Ocaml.4.14.0 package.
+  $ mkdir -p REPO/packages/ocaml/ocaml.4.14.0
+  $ cat > REPO/packages/ocaml/ocaml.4.14.0/opam << EOF
+  > opam-version: "2.0"
+  > depends: [
+  >   ("ocaml-system" | "ocaml-base-compiler")
+  >   "ocaml-config"
+  > ]
+  > url {
+  >  src: "file://./compile.tar.gz"
+  >  checksum: "sha256=$SHA"
+  > }
+  > EOF
+Ocaml-base-compiler.4.14.0 package.
+  $ mkdir -p REPO/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0
+  $ cat > REPO/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/opam << EOF
+  > opam-version: "2.0"
+  > build: [ "sh" "compile" name ]
+  > install: [
+  >  [ "chmod" "+x" "compile" ]
+  >  [ "cp" "compile" "%{bin}%/ocaml" ]
+  > ]
+  > url {
+  >  src: "file://./ocaml.tar.gz"
+  >  checksum: "sha256=$OCAMLSHA"
+  > }
+  > EOF
+Opam setup
+  $ mkdir $OPAMROOT
+  $ opam init --bare ./REPO --no-setup --bypass-checks
+  No configuration file found, using built-in defaults.
+  
+  <><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
+  [default] Initialised
+  $ opam switch create one --empty
+
+
+
+Running opam-bundle with sanitized output that contains replaced platform specific information.
+
+
+============================== Test 1 ==============================
+
+
+Bundle single package `bar` of version 2. That implies installation of its dependency `foo` with constraint "<=2".
+
+  $ opam-bundle bar.2 --repository ./REPO --ocaml=4.14.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  No environment specified, will use the following for package resolution (based on the host system):
+    - arch = $ARCH
+    - os = $OS
+    - os-distribution = $OSDISTRIB
+    - os-version = $OSVERSION
+    - os-family = $OSFAMILLY
+  
+  <><> Initialising repositories ><><><><><><><><><><><><><><><><><><><><><><><><>
+  [home] Initialised
+  
+  <><> Resolving package set ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  The following packages will be included:
+    - bar.2
+    - foo.2
+    - ocaml.4.14.0
+    - ocaml-base-compiler.4.14.0
+    - ocaml-bootstrap.4.14.0
+    - ocaml-config.2
+  According to the packages' metadata, the bundle should be installable on any arch/OS.
+  [NOTE] Opam system sandboxing (introduced in 2.0) will be disabled in the bundle. You need to trust that the build scripts of the included packages don't write outside of their build directory and dest dir.
+  Continue ? [Y/n] y
+  
+  <><> Getting all archives <><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  
+  <><> Getting bootstrap packages <><><><><><><><><><><><><><><><><><><><><><><><>
+  
+  <><> Building bundle ><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  Done. Bundle generated as $TESTCASE_ROOT/bar-bundle.tar.gz
+  $ tar xvf bar-bundle.tar.gz | grep -v sha256 | sort
+  bar-bundle/
+  bar-bundle/bootstrap.sh
+  bar-bundle/common.sh
+  bar-bundle/compile.sh
+  bar-bundle/configure.sh
+  bar-bundle/opam-full-2.1.0-rc2.tar.gz
+  bar-bundle/repo/
+  bar-bundle/repo/archives/
+  bar-bundle/repo/archives/bar.2/
+  bar-bundle/repo/archives/bar.2/compile2.tar.gz
+  bar-bundle/repo/archives/foo.2/
+  bar-bundle/repo/archives/foo.2/compile2.tar.gz
+  bar-bundle/repo/archives/ocaml-base-compiler.4.14.0/
+  bar-bundle/repo/archives/ocaml-base-compiler.4.14.0/ocaml.tar.gz
+  bar-bundle/repo/archives/ocaml.4.14.0/
+  bar-bundle/repo/archives/ocaml.4.14.0/compile.tar.gz
+  bar-bundle/repo/cache/
+  bar-bundle/repo/packages/
+  bar-bundle/repo/packages/bar/
+  bar-bundle/repo/packages/bar/bar.2/
+  bar-bundle/repo/packages/bar/bar.2/opam
+  bar-bundle/repo/packages/foo/
+  bar-bundle/repo/packages/foo/foo.2/
+  bar-bundle/repo/packages/foo/foo.2/opam
+  bar-bundle/repo/packages/ocaml-base-compiler/
+  bar-bundle/repo/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/
+  bar-bundle/repo/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/opam
+  bar-bundle/repo/packages/ocaml-bootstrap/
+  bar-bundle/repo/packages/ocaml-bootstrap/ocaml-bootstrap.4.14.0/
+  bar-bundle/repo/packages/ocaml-bootstrap/ocaml-bootstrap.4.14.0/opam
+  bar-bundle/repo/packages/ocaml-config/
+  bar-bundle/repo/packages/ocaml-config/ocaml-config.2/
+  bar-bundle/repo/packages/ocaml-config/ocaml-config.2/opam
+  bar-bundle/repo/packages/ocaml/
+  bar-bundle/repo/packages/ocaml/ocaml.4.14.0/
+  bar-bundle/repo/packages/ocaml/ocaml.4.14.0/opam
+  bar-bundle/repo/repo
+
+  $ sh ./bar-bundle/compile.sh ../BAR
+  This bundle will compile the application to $TESTCASE_ROOT/bar-bundle, and put wrappers into
+  ../BAR/bin. You will need to retain $TESTCASE_ROOT/bar-bundle for the wrappers to work.
+  
+  Press enter to continue... 
+  ================ Bootstrap: checking for prerequisites         ================
+  
+  Checking for cc... found
+  Checking for make... found
+  Checking for wget curl... found
+  Checking for patch... found
+  Checking for unzip... found
+  Checking for bunzip2... found
+  Checking for rsync... found
+  
+  ================ Bootstrap: compiling OCaml                    ================
+  
+  This may take a while. Output is in $TESTCASE_ROOT/bar-bundle/bootstrap.log
+  Uncompressing... done
+  Configuring... done
+  Compiling... done
+  Installing to temp prefix... done
+  Already compiled opam found
+  
+  ================ Configure: initialising opam                  ================
+  
+  Output is in $TESTCASE_ROOT/bar-bundle/configure.log
+  Initialising... done
+  Creating sandbox... done
+  
+  ================ Compile: installing packages                  ================
+  
+  Output is in $TESTCASE_ROOT/bar-bundle/compile.log
+  Compiling packages... done
+  Cleaning up... done
+  Wrapper bar installed successfully.
+
+  $ opam exec --root ./bar-bundle/opam -- foo
+  I'm launching foo v.2 !
+  $ opam exec --root ./bar-bundle/opam -- bar
+  I'm launching bar v.2 !
+  $ find BAR | sort
+  BAR
+  BAR/bin
+  BAR/bin/bar
+  $ BAR/bin/bar
+  I'm launching bar v.2 !
+
+Cleaning up
+  $ rm -r BAR bar-bundle bar-bundle.tar.gz
+
+
+============================== Test 2 ==============================
+
+
+Bundle two packages `bar` and `foo>2`. Forcing constraint on `foo` implies installation of `bar.3`.
+Since `foo` was specified as argument to `opam-bundle` it installs additionally `foo` wrapper.
+
+  $ opam-bundle bar 'foo>2' --repository ./REPO --ocaml=4.14.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  No environment specified, will use the following for package resolution (based on the host system):
+    - arch = $ARCH
+    - os = $OS
+    - os-distribution = $OSDISTRIB
+    - os-version = $OSVERSION
+    - os-family = $OSFAMILLY
+  
+  <><> Initialising repositories ><><><><><><><><><><><><><><><><><><><><><><><><>
+  [home] Initialised
+  
+  <><> Resolving package set ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  The following packages will be included:
+    - bar.3
+    - foo.3
+    - ocaml.4.14.0
+    - ocaml-base-compiler.4.14.0
+    - ocaml-bootstrap.4.14.0
+    - ocaml-config.2
+  According to the packages' metadata, the bundle should be installable on any arch/OS.
+  [NOTE] Opam system sandboxing (introduced in 2.0) will be disabled in the bundle. You need to trust that the build scripts of the included packages don't write outside of their build directory and dest dir.
+  Continue ? [Y/n] y
+  
+  <><> Getting all archives <><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  
+  <><> Getting bootstrap packages <><><><><><><><><><><><><><><><><><><><><><><><>
+  
+  <><> Building bundle ><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  Done. Bundle generated as $TESTCASE_ROOT/bar-bundle.tar.gz
+  $ tar xvf bar-bundle.tar.gz | grep -v sha256 | sort
+  bar-bundle/
+  bar-bundle/bootstrap.sh
+  bar-bundle/common.sh
+  bar-bundle/compile.sh
+  bar-bundle/configure.sh
+  bar-bundle/opam-full-2.1.0-rc2.tar.gz
+  bar-bundle/repo/
+  bar-bundle/repo/archives/
+  bar-bundle/repo/archives/bar.3/
+  bar-bundle/repo/archives/bar.3/compile3.tar.gz
+  bar-bundle/repo/archives/foo.3/
+  bar-bundle/repo/archives/foo.3/compile3.tar.gz
+  bar-bundle/repo/archives/ocaml-base-compiler.4.14.0/
+  bar-bundle/repo/archives/ocaml-base-compiler.4.14.0/ocaml.tar.gz
+  bar-bundle/repo/archives/ocaml.4.14.0/
+  bar-bundle/repo/archives/ocaml.4.14.0/compile.tar.gz
+  bar-bundle/repo/cache/
+  bar-bundle/repo/packages/
+  bar-bundle/repo/packages/bar/
+  bar-bundle/repo/packages/bar/bar.3/
+  bar-bundle/repo/packages/bar/bar.3/files/
+  bar-bundle/repo/packages/bar/bar.3/files/test.patch
+  bar-bundle/repo/packages/bar/bar.3/opam
+  bar-bundle/repo/packages/foo/
+  bar-bundle/repo/packages/foo/foo.3/
+  bar-bundle/repo/packages/foo/foo.3/opam
+  bar-bundle/repo/packages/ocaml-base-compiler/
+  bar-bundle/repo/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/
+  bar-bundle/repo/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/opam
+  bar-bundle/repo/packages/ocaml-bootstrap/
+  bar-bundle/repo/packages/ocaml-bootstrap/ocaml-bootstrap.4.14.0/
+  bar-bundle/repo/packages/ocaml-bootstrap/ocaml-bootstrap.4.14.0/opam
+  bar-bundle/repo/packages/ocaml-config/
+  bar-bundle/repo/packages/ocaml-config/ocaml-config.2/
+  bar-bundle/repo/packages/ocaml-config/ocaml-config.2/opam
+  bar-bundle/repo/packages/ocaml/
+  bar-bundle/repo/packages/ocaml/ocaml.4.14.0/
+  bar-bundle/repo/packages/ocaml/ocaml.4.14.0/opam
+  bar-bundle/repo/repo
+
+  $ sh ./bar-bundle/compile.sh ../BAR
+  This bundle will compile the application to $TESTCASE_ROOT/bar-bundle, and put wrappers into
+  ../BAR/bin. You will need to retain $TESTCASE_ROOT/bar-bundle for the wrappers to work.
+  
+  Press enter to continue... 
+  ================ Bootstrap: checking for prerequisites         ================
+  
+  Checking for cc... found
+  Checking for make... found
+  Checking for wget curl... found
+  Checking for patch... found
+  Checking for unzip... found
+  Checking for bunzip2... found
+  Checking for rsync... found
+  
+  ================ Bootstrap: compiling OCaml                    ================
+  
+  This may take a while. Output is in $TESTCASE_ROOT/bar-bundle/bootstrap.log
+  Uncompressing... done
+  Configuring... done
+  Compiling... done
+  Installing to temp prefix... done
+  Already compiled opam found
+  
+  ================ Configure: initialising opam                  ================
+  
+  Output is in $TESTCASE_ROOT/bar-bundle/configure.log
+  Initialising... done
+  Creating sandbox... done
+  
+  ================ Compile: installing packages                  ================
+  
+  Output is in $TESTCASE_ROOT/bar-bundle/compile.log
+  Compiling packages... done
+  Cleaning up... done
+  Wrapper bar installed successfully.
+  Wrapper foo installed successfully.
+
+  $ opam exec --root ./bar-bundle/opam -- foo
+  I'm launching foo v.3 !
+  $ opam exec --root ./bar-bundle/opam -- bar
+  I'm launching with patch bar v.3 !
+  $ find BAR | sort
+  BAR
+  BAR/bin
+  BAR/bin/bar
+  BAR/bin/foo
+  $ BAR/bin/foo
+  I'm launching foo v.3 !
+  $ BAR/bin/bar
+  I'm launching with patch bar v.3 !
+
+Cleaning up
+  $ rm -r BAR bar-bundle bar-bundle.tar.gz
+
+
+============================== Test 3 ==============================
+
+
+Bundle two packages `bar` and `foo@foo.4` where "foo.4" is a url to local version of package `foo`. This package
+has extra-source (opam-bundle archive 0.4) that should be also bundled. Forcing constraint on `foo` implies
+installation of `bar.3`. Since `foo` was specified as argument to `opam-bundle` it installs additionally `foo`
+wrapper.
+
+  $ opam-bundle bar 'foo@foo.4' --repository ./REPO --ocaml=4.14.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/;s/md5=.*/md5=$HASH/' | sed 's/.* No such file or directory/mv error/g'
+  No environment specified, will use the following for package resolution (based on the host system):
+    - arch = $ARCH
+    - os = $OS
+    - os-distribution = $OSDISTRIB
+    - os-version = $OSVERSION
+    - os-family = $OSFAMILLY
+  
+  <><> Initialising repositories ><><><><><><><><><><><><><><><><><><><><><><><><>
+  [home] Initialised
+  
+  <><> Getting external packages ><><><><><><><><><><><><><><><><><><><><><><><><>
+  [NOTE] Will use package definition found in source for foo
+  
+  <><> Resolving package set ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  The following packages will be included:
+    - bar.3
+    - foo.4
+    - ocaml.4.14.0
+    - ocaml-base-compiler.4.14.0
+    - ocaml-bootstrap.4.14.0
+    - ocaml-config.2
+  According to the packages' metadata, the bundle should be installable on any arch/OS.
+  [NOTE] Opam system sandboxing (introduced in 2.0) will be disabled in the bundle. You need to trust that the build scripts of the included packages don't write outside of their build directory and dest dir.
+  Continue ? [Y/n] y
+  
+  <><> Getting all archives <><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  Fatal error:
+  mv error"
+
+Full error is
+"/usr/bin/mv /tmp/build_e9e480_dune/opam-1420667-a450af/foo.4 /tmp/build_e9e480_dune/opam-1420667-81a3f8/bar-bundle/repo/cache/md5/fa/fa3f5d536909bb625ae9f77392261a3f" exited with code 1 "/usr/bin/mv: cannot move '/tmp/build_e9e480_dune/opam-1420667-a450af/foo.4' to '/tmp/build_e9e480_dune/opam-1420667-81a3f8/bar-bundle/repo/cache/md5/fa/fa3f5d536909bb625ae9f77392261a3f': No such file or directory"
+
+  $ tar xvf bar-bundle.tar.gz | grep -v sha256 | grep -v md5 | sort
+  tar: bar-bundle.tar.gz: Cannot open: No such file or directory
+  tar: Error is not recoverable: exiting now
+
+  $ sh ./bar-bundle/compile.sh ../BAR
+  sh: 0: cannot open ./bar-bundle/compile.sh: No such file
+  [2]
+
+  $ opam exec --root ./bar-bundle/opam -- foo
+  [ERROR] Opam has not been initialised, please run `opam init'
+  [50]
+  $ opam exec --root ./bar-bundle/opam -- bar
+  [ERROR] Opam has not been initialised, please run `opam init'
+  [50]
+  $ find BAR | sort
+  find: 'BAR': No such file or directory
+  $ BAR/bin/foo
+  BAR/bin/foo: not found
+  [127]
+  $ BAR/bin/bar
+  BAR/bin/bar: not found
+  [127]
+
+
+
+============================== Test 4 (fail) ==============================
+
+
+Trying to bundle two packages `bar.3` and `foo.1`. This should fail, because those versions are not compatible.
+
+  $ opam-bundle bar.3 foo.1 --repository ./REPO --ocaml=4.14.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  No environment specified, will use the following for package resolution (based on the host system):
+    - arch = $ARCH
+    - os = $OS
+    - os-distribution = $OSDISTRIB
+    - os-version = $OSVERSION
+    - os-family = $OSFAMILLY
+  
+  <><> Initialising repositories ><><><><><><><><><><><><><><><><><><><><><><><><>
+  [home] Initialised
+  
+  <><> Resolving package set ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  [ERROR] No solution for bar.3 & foo.1 & ocaml-bootstrap.4.14.0:   * No agreement on the version of foo:
+              - bar >= 3 -> foo >= 3
+              - foo < 2
+  
+  
+
+
+
+============================== Test 5 (fail) ==============================
+
+
+Trying to bundle two packages `bar` and `foo<3@foo.4`. This should fail, because package with url can be constrained only with '.' or '='.
+
+  $ opam-bundle bar 'foo<2@foo.4' --repository ./REPO --ocaml=4.14.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  opam-bundle: PACKAGE… arguments: Only equality version constraints can be
+               specified together with a target URL
+  Usage: opam-bundle [OPTION]… PACKAGE…
+  Try 'opam-bundle --help' for more information.

--- a/tests/stub/repos.t
+++ b/tests/stub/repos.t
@@ -1,0 +1,384 @@
+This test verify different repository specifications that could be used with `opam-bundle`.
+Every package used is a stub package.
+
+  $ export OPAMNOENVNOTICE=1
+  $ export OPAMYES=1
+  $ export OPAMROOT=$PWD/OPAMROOT
+  $ export OPAMSTATUSLINE=never
+  $ export OPAMVERBOSE=-1
+  $ opam --version
+  2.1.4
+Stub executable
+  $ cat > compile << EOF
+  > #!/bin/sh
+  > echo "I'm launching \$(basename \${0}) \$@!"
+  > EOF
+  $ chmod +x compile
+  $ tar czf compile.tar.gz compile
+  $ SHA=`openssl sha256 compile.tar.gz | cut -d ' ' -f 2`
+OCaml archives setup
+4.14
+  $ mkdir ocaml-4.14.0
+  $ cat > ocaml-4.14.0/configure << EOF
+  > set -uex
+  > sed -i "s:PREFIX:\$2:g" Makefile
+  > echo "configured"
+  > EOF
+  $ chmod +x ocaml-4.14.0/configure
+  $ cat > ocaml-4.14.0/Makefile << EOF
+  > world:
+  > 	echo "make world"
+  > world.opt:
+  > 	echo "world opt"
+  > install:
+  > 	mkdir -p PREFIX/bin/
+  > 	cp ocaml PREFIX/bin/
+  > 	cp ocamlc PREFIX/bin/
+  > 	cp ocamlopt PREFIX/bin/
+  > 	cp $(which opam) PREFIX/bin/
+  > EOF
+  $ cat > ocaml-4.14.0/ocaml << EOF
+  > echo "I'm compiling v.4.14 \$1!"
+  > EOF
+  $ cp ocaml-4.14.0/ocaml ocaml-4.14.0/ocamlc
+  $ cp ocaml-4.14.0/ocaml ocaml-4.14.0/ocamlopt
+  $ tar czf ocaml.4.14.tar.gz ocaml-4.14.0
+  $ OCAMLSHA414=`openssl sha256 ocaml.4.14.tar.gz | cut -d ' ' -f 2`
+4.13
+  $ mkdir ocaml-4.13.0
+  $ cat > ocaml-4.13.0/configure << EOF
+  > set -uex
+  > sed -i "s:PREFIX:\$2:g" Makefile
+  > echo "configured"
+  > EOF
+  $ chmod +x ocaml-4.13.0/configure
+  $ cat > ocaml-4.13.0/Makefile << EOF
+  > world:
+  > 	echo "make world"
+  > world.opt:
+  > 	echo "world opt"
+  > install:
+  > 	mkdir -p PREFIX/bin/
+  > 	cp ocaml PREFIX/bin/
+  > 	cp ocamlc PREFIX/bin/
+  > 	cp ocamlopt PREFIX/bin/
+  > 	cp $(which opam) PREFIX/bin/
+  > EOF
+  $ cat > ocaml-4.13.0/ocaml << EOF
+  > echo "I'm compiling v.4.13 \$1!"
+  > EOF
+  $ cp ocaml-4.13.0/ocaml ocaml-4.13.0/ocamlc
+  $ cp ocaml-4.13.0/ocaml ocaml-4.13.0/ocamlopt
+  $ tar czf ocaml.4.13.tar.gz ocaml-4.13.0
+  $ OCAMLSHA413=`openssl sha256 ocaml.4.13.tar.gz | cut -d ' ' -f 2`
+4.12
+  $ mkdir ocaml-4.12.0
+  $ cat > ocaml-4.12.0/configure << EOF
+  > set -uex
+  > sed -i "s:PREFIX:\$2:g" Makefile
+  > echo "configured"
+  > EOF
+  $ chmod +x ocaml-4.12.0/configure
+  $ cat > ocaml-4.12.0/Makefile << EOF
+  > world:
+  > 	echo "make world"
+  > world.opt:
+  > 	echo "world opt"
+  > install:
+  > 	mkdir -p PREFIX/bin/
+  > 	cp ocaml PREFIX/bin/
+  > 	cp ocamlc PREFIX/bin/
+  > 	cp ocamlopt PREFIX/bin/
+  > 	cp $(which opam) PREFIX/bin/
+  > EOF
+  $ cat > ocaml-4.12.0/ocaml << EOF
+  > echo "I'm compiling v.4.12 \$1!"
+  > EOF
+  $ cp ocaml-4.12.0/ocaml ocaml-4.12.0/ocamlc
+  $ cp ocaml-4.12.0/ocaml ocaml-4.12.0/ocamlopt
+  $ tar czf ocaml.4.12.tar.gz ocaml-4.12.0
+  $ OCAMLSHA412=`openssl sha256 ocaml.4.12.tar.gz | cut -d ' ' -f 2`
+Repos setup
+  $ mkdir -p REPO1/packages/ REPO2/packages/ REPO3/packages/
+  $ cat > REPO1/repo << EOF
+  > opam-version: "2.0"
+  > EOF
+  $ cat > REPO2/repo << EOF
+  > opam-version: "2.0"
+  > EOF
+  $ cat > REPO3/repo << EOF
+  > opam-version: "2.0"
+  > EOF
+Ocaml-system.4.14.0 package.
+  $ mkdir -p REPO1/packages/ocaml-system/ocaml-system.4.14.0
+  $ cat > REPO1/packages/ocaml-system/ocaml-system.4.14.0/opam << EOF
+  > opam-version: "2.0"
+  > EOF
+Ocaml.4.14.0 package.
+  $ mkdir -p REPO1/packages/ocaml/ocaml.4.14.0
+  $ cat > REPO1/packages/ocaml/ocaml.4.14.0/opam << EOF
+  > opam-version: "2.0"
+  > depends: [
+  >   ("ocaml-system" | "ocaml-base-compiler")
+  >   "ocaml-config"
+  > ]
+  > url {
+  >  src: "file://./compile.tar.gz"
+  >  checksum: "sha256=$SHA"
+  > }
+  > EOF
+Ocaml-base-compiler.4.14.0 package.
+  $ mkdir -p REPO1/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0
+  $ cat > REPO1/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/opam << EOF
+  > opam-version: "2.0"
+  > build: [ "sh" "compile" name ]
+  > install: [
+  >  [ "chmod" "+x" "compile" ]
+  >  [ "cp" "compile" "%{bin}%/ocaml" ]
+  > ]
+  > url {
+  >  src: "file://./ocaml.4.14.tar.gz"
+  >  checksum: "sha256=$OCAMLSHA414"
+  > }
+  > EOF
+Ocaml-system.4.13.0 package.
+  $ mkdir -p REPO2/packages/ocaml-system/ocaml-system.4.13.0
+  $ cat > REPO2/packages/ocaml-system/ocaml-system.4.13.0/opam << EOF
+  > opam-version: "2.0"
+  > EOF
+Ocaml.4.13.0 package.
+  $ mkdir -p REPO2/packages/ocaml/ocaml.4.13.0
+  $ cat > REPO2/packages/ocaml/ocaml.4.13.0/opam << EOF
+  > opam-version: "2.0"
+  > depends: [
+  >   ("ocaml-system" | "ocaml-base-compiler")
+  >   "ocaml-config"
+  > ]
+  > url {
+  >  src: "file://./compile.tar.gz"
+  >  checksum: "sha256=$SHA"
+  > }
+  > EOF
+Ocaml-base-compiler.4.13.0 package.
+  $ mkdir -p REPO2/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0
+  $ cat > REPO2/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0/opam << EOF
+  > opam-version: "2.0"
+  > build: [ "sh" "compile" name ]
+  > install: [
+  >  [ "chmod" "+x" "compile" ]
+  >  [ "cp" "compile" "%{bin}%/ocaml" ]
+  > ]
+  > url {
+  >  src: "file://./ocaml.4.13.tar.gz"
+  >  checksum: "sha256=$OCAMLSHA413"
+  > }
+  > EOF
+Ocaml-system.4.12.0 package.
+  $ mkdir -p REPO3/packages/ocaml-system/ocaml-system.4.12.0
+  $ cat > REPO3/packages/ocaml-system/ocaml-system.4.12.0/opam << EOF
+  > opam-version: "2.0"
+  > EOF
+Ocaml.4.12.0 package.
+  $ mkdir -p REPO3/packages/ocaml/ocaml.4.12.0
+  $ cat > REPO3/packages/ocaml/ocaml.4.12.0/opam << EOF
+  > opam-version: "2.0"
+  > depends: [
+  >   ("ocaml-system" | "ocaml-base-compiler")
+  >   "ocaml-config"
+  > ]
+  > url {
+  >  src: "file://./compile.tar.gz"
+  >  checksum: "sha256=$SHA"
+  > }
+  > EOF
+Ocaml-base-compiler.4.12.0 package.
+  $ mkdir -p REPO3/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0
+  $ cat > REPO3/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0/opam << EOF
+  > opam-version: "2.0"
+  > build: [ "sh" "compile" name ]
+  > install: [
+  >  [ "chmod" "+x" "compile" ]
+  >  [ "cp" "compile" "%{bin}%/ocaml" ]
+  > ]
+  > url {
+  >  src: "file://./ocaml.4.12.tar.gz"
+  >  checksum: "sha256=$OCAMLSHA412"
+  > }
+  > EOF
+Ocaml-config.2 package.
+  $ mkdir -p REPO3/packages/ocaml-config/ocaml-config.2
+  $ cat > REPO3/packages/ocaml-config/ocaml-config.2/opam << EOF
+  > opam-version: "2.0"
+  > EOF
+=== Foo package ===
+  $ mkdir -p REPO1/packages/foo/foo.1
+  $ cat > REPO1/packages/foo/foo.1/opam << EOF
+  > opam-version: "2.0"
+  > version: "1"
+  > build: [ "sh" "compile" name ]
+  > install: [
+  >  [ "cp" "compile" "%{bin}%/%{name}%" ]
+  > ]
+  > depends : [
+  >  "ocaml" {>= "4.12.0"}
+  > ]
+  > url {
+  >  src: "file://./compile.tar.gz"
+  >  checksum: "sha256=$SHA"
+  > }
+  > EOF
+=== Bar package (not available on cygwin) ===
+  $ mkdir -p REPO2/packages/bar/bar.1
+  $ cat > REPO2/packages/bar/bar.1/opam << EOF
+  > opam-version: "2.0"
+  > version: "1"
+  > build: [ "sh" "compile" name ]
+  > install: [
+  >  [ "cp" "compile" "%{bin}%/%{name}%" ]
+  > ]
+  > depends : [
+  >  "ocaml" {>= "4.13.0"}
+  >  "foo"
+  > ]
+  > url {
+  >  src: "file://./compile.tar.gz"
+  >  checksum: "sha256=$SHA"
+  > }
+  > EOF
+Opam setup
+  $ mkdir $OPAMROOT
+  $ opam init --bare repo1 ./REPO1 --no-setup --bypass-checks
+  No configuration file found, using built-in defaults.
+  
+  <><> Fetching repository information ><><><><><><><><><><><><><><><><><><><><><>
+  [repo1] Initialised
+
+  $ opam switch create one --empty
+
+  $ opam repo add repo2 ./REPO2 --all-switches
+  [repo2] Initialised
+  $ opam repo add repo3 ./REPO3 --all-switches
+  [repo3] Initialised
+
+
+
+
+Running opam-bundle with sanitized output that contains replaced platform specific information.
+
+
+============================== Test 1 ==============================
+
+
+Bundle package foo with and specifyng two repositories with `ocaml.4.12` and second repository containing
+only `ocaml.4.14` packages. We are forcing here to use 4.12 from second switch.
+
+  $ opam-bundle foo --repository ./REPO1 --repository ./REPO3 --ocaml=4.12.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  No environment specified, will use the following for package resolution (based on the host system):
+    - arch = $ARCH
+    - os = $OS
+    - os-distribution = $OSDISTRIB
+    - os-version = $OSVERSION
+    - os-family = $OSFAMILLY
+  
+  <><> Initialising repositories ><><><><><><><><><><><><><><><><><><><><><><><><>
+  [home] Initialised
+  [home1] Initialised
+  
+  <><> Resolving package set ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  The following packages will be included:
+    - foo.1
+    - ocaml.4.12.0
+    - ocaml-base-compiler.4.12.0
+    - ocaml-bootstrap.4.12.0
+    - ocaml-config.2
+  According to the packages' metadata, the bundle should be installable on any arch/OS.
+  [NOTE] Opam system sandboxing (introduced in 2.0) will be disabled in the bundle. You need to trust that the build scripts of the included packages don't write outside of their build directory and dest dir.
+  Continue ? [Y/n] y
+  
+  <><> Getting all archives <><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  
+  <><> Getting bootstrap packages <><><><><><><><><><><><><><><><><><><><><><><><>
+  
+  <><> Building bundle ><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  Done. Bundle generated as $TESTCASE_ROOT/foo-bundle.tar.gz
+
+
+
+============================== Test 2 ==============================
+
+
+
+Bundle packages foo and bar with specifying three repositories with `foo` and second repository containing `bar`
+package and third containing required ocaml-config.2. We are forcing here to use 4.13 from switch.
+
+  $ opam-bundle foo bar --repository ./REPO1 --repository ./REPO2 --repository ./REPO3 --ocaml=4.13.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  No environment specified, will use the following for package resolution (based on the host system):
+    - arch = $ARCH
+    - os = $OS
+    - os-distribution = $OSDISTRIB
+    - os-version = $OSVERSION
+    - os-family = $OSFAMILLY
+  
+  <><> Initialising repositories ><><><><><><><><><><><><><><><><><><><><><><><><>
+  [home] Initialised
+  [home1] Initialised
+  [home2] Initialised
+  
+  <><> Resolving package set ><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  The following packages will be included:
+    - bar.1
+    - foo.1
+    - ocaml.4.13.0
+    - ocaml-base-compiler.4.13.0
+    - ocaml-bootstrap.4.13.0
+    - ocaml-config.2
+  According to the packages' metadata, the bundle should be installable on any arch/OS.
+  [NOTE] Opam system sandboxing (introduced in 2.0) will be disabled in the bundle. You need to trust that the build scripts of the included packages don't write outside of their build directory and dest dir.
+  Continue ? [Y/n] y
+  
+  <><> Getting all archives <><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  
+  <><> Getting bootstrap packages <><><><><><><><><><><><><><><><><><><><><><><><>
+  
+  <><> Building bundle ><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  Done. Bundle generated as $TESTCASE_ROOT/foo-bundle.tar.gz
+
+
+
+============================== Test 3 (fail) ==============================
+
+
+
+Trying bundle foo package with a repository that hasn't required package (ocaml-config). That should fail.
+
+  $ opam-bundle foo --repository ./REPO1 --ocaml=4.14.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  No environment specified, will use the following for package resolution (based on the host system):
+    - arch = $ARCH
+    - os = $OS
+    - os-distribution = $OSDISTRIB
+    - os-version = $OSVERSION
+    - os-family = $OSFAMILLY
+  
+  <><> Initialising repositories ><><><><><><><><><><><><><><><><><><><><><><><><>
+  [home] Initialised
+  [ERROR] Package ocaml-config.2 not found in the repositories
+
+
+
+============================== Test 4 (fail) ==============================
+
+
+Trying bundle foo package with a repositories that hasn't required ocaml version. That should fail.
+
+  $ opam-bundle foo --repository ./REPO1 --repository ./REPO3 --ocaml=4.13.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  No environment specified, will use the following for package resolution (based on the host system):
+    - arch = $ARCH
+    - os = $OS
+    - os-distribution = $OSDISTRIB
+    - os-version = $OSVERSION
+    - os-family = $OSFAMILLY
+  
+  <><> Initialising repositories ><><><><><><><><><><><><><><><><><><><><><><><><>
+  [home] Initialised
+  [home1] Initialised
+  [ERROR] Package ocaml-system.4.13.0 not found in the repositories


### PR DESCRIPTION
This PR adds cram tests mechanism integrated in `dune` workflow.
It contains 2 test suites:
- Tests with dummy config that examine `opam-bundle` from different direction and also to ensure that generated bundle contains exactly what needed.
- Tests with real packages and repositories.