### PR TITLE
Fix : opam version bindings

### DIFF
--- a/tests/real/odoc.t
+++ b/tests/real/odoc.t
@@ -8,6 +8,8 @@ This test verify bundling of real package `odoc` with compiler version 4.02.3 an
   $ opam --version
   2.1.4
   $ opam-bundle odoc --ocaml=4.02.3 --opam=2.0 --self --yes 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  OCaml version is set to 4.02.3.
+  Opam version is set to 2.0.10.
   No environment specified, will use the following for package resolution (based on the host system):
     - arch = $ARCH
     - os = $OS

--- a/tests/real/odoc.t
+++ b/tests/real/odoc.t
@@ -5,8 +5,6 @@ This test verify bundling of real package `odoc` with compiler version 4.02.3 an
   $ export OPAMROOT=$PWD/OPAMROOT
   $ export OPAMSTATUSLINE=never
   $ export OPAMVERBOSE=-1
-  $ opam --version
-  2.1.4
   $ opam-bundle odoc --ocaml=4.02.3 --opam=2.0 --self --yes 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
   OCaml version is set to 4.02.3.
   Opam version is set to 2.0.10.
@@ -58,13 +56,62 @@ This test verify bundling of real package `odoc` with compiler version 4.02.3 an
   <><> Getting all archives <><><><><><><><><><><><><><><><><><><><><><><><><><><>
   
   <><> Getting bootstrap packages <><><><><><><><><><><><><><><><><><><><><><><><>
-  [ERROR] Opam archive at https://github.com/ocaml/opam/releases/download/2.0/opam-full-2.0.tar.gz could not be obtained: curl error code 404
+  
+  <><> Building bundle ><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  Done. Bundle generated as $TESTCASE_ROOT/odoc-bundle.tar.gz
+  Self-extracting archive generated as $TESTCASE_ROOT/odoc-bundle.sh
   $ sh ./odoc-bundle.sh -y
-  sh: 0: cannot open ./odoc-bundle.sh: No such file
+  This bundle will compile the application to $TESTCASE_ROOT/odoc-bundle, WITHOUT installing
+  wrappers anywhere else.
+  
+  ================ Bootstrap: checking for prerequisites         ================
+  
+  Checking for cc... found
+  Checking for make... found
+  Checking for wget curl... found
+  Checking for patch... found
+  Checking for unzip... found
+  Checking for bunzip2... found
+  Checking for rsync... found
+  
+  ================ Bootstrap: compiling OCaml                    ================
+  
+  This may take a while. Output is in $TESTCASE_ROOT/odoc-bundle/bootstrap.log
+  Uncompressing... 
+  
+  Something went wrong, see log in $TESTCASE_ROOT/odoc-bundle/bootstrap.log
   [2]
   $ sh ./odoc-bundle/compile.sh ../ODOC
-  sh: 0: cannot open ./odoc-bundle/compile.sh: No such file
-  [2]
+  This bundle will compile the application to $TESTCASE_ROOT/odoc-bundle, and put wrappers into
+  ../ODOC/bin. You will need to retain $TESTCASE_ROOT/odoc-bundle for the wrappers to work.
+  
+  Press enter to continue... 
+  ================ Bootstrap: checking for prerequisites         ================
+  
+  Checking for cc... found
+  Checking for make... found
+  Checking for wget curl... found
+  Checking for patch... found
+  Checking for unzip... found
+  Checking for bunzip2... found
+  Checking for rsync... found
+  
+  ================ Bootstrap: compiling OCaml                    ================
+  
+  This may take a while. Output is in $TESTCASE_ROOT/odoc-bundle/bootstrap.log
+  Uncompressing... 
+  
+  Something went wrong, see log in $TESTCASE_ROOT/odoc-bundle/bootstrap.log
+  
+  ================ Compile: installing packages                  ================
+  
+  Output is in $TESTCASE_ROOT/odoc-bundle/compile.log
+  ./odoc-bundle/compile.sh: 59: cannot create $TESTCASE_ROOT/odoc-bundle/bootstrap/bin/sudo: Directory nonexistent
+  chmod: cannot access '$TESTCASE_ROOT/odoc-bundle/bootstrap/bin/sudo': No such file or directory
+  Compiling packages... 
+  
+  Something went wrong, see log in $TESTCASE_ROOT/odoc-bundle/compile.log
+  [50]
   $ ODOC/bin/odoc
   ODOC/bin/odoc: not found
   [127]

--- a/tests/real/opam-bundle.t
+++ b/tests/real/opam-bundle.t
@@ -8,6 +8,8 @@ This test verify bundling of real package `opam-bundle` of version 0.4.
   $ opam --version
   2.1.4
   $ opam-bundle "opam-bundle@https://github.com/AltGr/opam-bundle/archive/refs/tags/0.4.tar.gz" opam-client.2.0.10 --self --opam=2.1 --ocaml=4.14.0 --yes 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  OCaml version is set to 4.14.0.
+  Opam version is set to 2.1.4.
   No environment specified, will use the following for package resolution (based on the host system):
     - arch = $ARCH
     - os = $OS
@@ -60,13 +62,88 @@ This test verify bundling of real package `opam-bundle` of version 0.4.
   <><> Getting all archives <><><><><><><><><><><><><><><><><><><><><><><><><><><>
   
   <><> Getting bootstrap packages <><><><><><><><><><><><><><><><><><><><><><><><>
-  [ERROR] Opam archive at https://github.com/ocaml/opam/releases/download/2.1/opam-full-2.1.tar.gz could not be obtained: curl error code 404
+  
+  <><> Building bundle ><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+  Done. Bundle generated as $TESTCASE_ROOT/opam-bundle-bundle.tar.gz
+  Self-extracting archive generated as $TESTCASE_ROOT/opam-bundle-bundle.sh
   $ sh ./opam-bundle-bundle.sh -y
-  sh: 0: cannot open ./opam-bundle-bundle.sh: No such file
-  [2]
+  This bundle will compile the application to $TESTCASE_ROOT/opam-bundle-bundle, WITHOUT installing
+  wrappers anywhere else.
+  
+  ================ Bootstrap: checking for prerequisites         ================
+  
+  Checking for cc... found
+  Checking for make... found
+  Checking for wget curl... found
+  Checking for patch... found
+  Checking for unzip... found
+  Checking for bunzip2... found
+  Checking for rsync... found
+  
+  ================ Bootstrap: compiling OCaml                    ================
+  
+  This may take a while. Output is in $TESTCASE_ROOT/opam-bundle-bundle/bootstrap.log
+  Uncompressing... done
+  Configuring... done
+  Compiling... done
+  Installing to temp prefix... done
+  
+  ================ Bootstrap: compiling opam                     ================
+  
+  This may take a while. Output is in $TESTCASE_ROOT/opam-bundle-bundle/bootstrap.log
+  Uncompressing... done
+  Configuring... done
+  Compiling extra dependencies... done
+  Compiling... done
+  Installing to temp prefix... done
+  
+  ================ Configure: initialising opam                  ================
+  
+  Output is in $TESTCASE_ROOT/opam-bundle-bundle/configure.log
+  Initialising... done
+  Creating sandbox... done
+  
+  ================ Compile: installing packages                  ================
+  
+  Output is in $TESTCASE_ROOT/opam-bundle-bundle/compile.log
+  Compiling packages... done
+  Cleaning up... done
+  
+  All compiled within $TESTCASE_ROOT/opam-bundle-bundle. To use the compiled packages:
+  
+    - either re-run opam-bundle-bundle/compile.sh with a PREFIX argument to install command wrappers
+      (it won't recompile everything)
+  
+    - or run the following to update the environment in the current shell, so that
+      they are in your PATH:
+        export PATH="$TESTCASE_ROOT/opam-bundle-bundle/bootstrap/bin:$PATH"; eval $(opam env --root "$TESTCASE_ROOT/opam-bundle-bundle/opam" --set-root)
+  
   $ sh ./opam-bundle-bundle/compile.sh ../BUNDLE
-  sh: 0: cannot open ./opam-bundle-bundle/compile.sh: No such file
-  [2]
+  This bundle will compile the application to $TESTCASE_ROOT/opam-bundle-bundle, and put wrappers into
+  ../BUNDLE/bin. You will need to retain $TESTCASE_ROOT/opam-bundle-bundle for the wrappers to work.
+  
+  Press enter to continue... 
+  ================ Bootstrap: checking for prerequisites         ================
+  
+  Checking for cc... found
+  Checking for make... found
+  Checking for wget curl... found
+  Checking for patch... found
+  Checking for unzip... found
+  Checking for bunzip2... found
+  Checking for rsync... found
+  Already compiled OCaml found
+  Already compiled opam found
+  Already initialised opam sandbox found
+  
+  ================ Compile: installing packages                  ================
+  
+  Output is in $TESTCASE_ROOT/opam-bundle-bundle/compile.log
+  Compiling packages... done
+  Cleaning up... done
+  Wrapper opam-bundle installed successfully.
   $ BUNDLE/bin/opam-bundle
-  BUNDLE/bin/opam-bundle: not found
-  [127]
+  opam-bundle: required argument PACKAGE is missing
+  Usage: opam-bundle [OPTION]… PACKAGE…
+  Try 'opam-bundle --help' for more information.
+  [1]

--- a/tests/real/opam-bundle.t
+++ b/tests/real/opam-bundle.t
@@ -5,8 +5,6 @@ This test verify bundling of real package `opam-bundle` of version 0.4.
   $ export OPAMROOT=$PWD/OPAMROOT
   $ export OPAMSTATUSLINE=never
   $ export OPAMVERBOSE=-1
-  $ opam --version
-  2.1.4
   $ opam-bundle "opam-bundle@https://github.com/AltGr/opam-bundle/archive/refs/tags/0.4.tar.gz" opam-client.2.0.10 --self --opam=2.1 --ocaml=4.14.0 --yes 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
   OCaml version is set to 4.14.0.
   Opam version is set to 2.1.4.

--- a/tests/stub/basic.t
+++ b/tests/stub/basic.t
@@ -8,8 +8,6 @@ Repo initial setup with two packages `foo` and `bar` that depends on `foo` and o
   $ export OPAMROOT=$PWD/OPAMROOT
   $ export OPAMSTATUSLINE=never
   $ export OPAMVERBOSE=-1
-  $ opam --version
-  2.1.4
   $ cat > compile << EOF
   > #!/bin/sh
   > echo "I'm launching \$(basename \${0}) \$@!"

--- a/tests/stub/basic.t
+++ b/tests/stub/basic.t
@@ -133,6 +133,8 @@ Running opam-bundle with sanitized output that contains remplaced platform speci
 Bundle single package `foo`.
 
   $ opam-bundle foo.1 --repository ./REPO --ocaml=4.14.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  OCaml version is set to 4.14.0.
+  No opam version selected, will use 2.1.4.
   No environment specified, will use the following for package resolution (based on the host system):
     - arch = $ARCH
     - os = $OS
@@ -164,7 +166,7 @@ Bundle single package `foo`.
   foo-bundle/common.sh
   foo-bundle/compile.sh
   foo-bundle/configure.sh
-  foo-bundle/opam-full-2.1.0-rc2.tar.gz
+  foo-bundle/opam-full-2.1.4.tar.gz
   foo-bundle/repo/
   foo-bundle/repo/archives/
   foo-bundle/repo/archives/foo.1/
@@ -238,6 +240,8 @@ Bundle single package `foo`.
 Bundle package `bar` that depends on `foo`.
 
   $ opam-bundle bar.1 --repository ./REPO --ocaml=4.14.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  OCaml version is set to 4.14.0.
+  No opam version selected, will use 2.1.4.
   No environment specified, will use the following for package resolution (based on the host system):
     - arch = $ARCH
     - os = $OS
@@ -270,7 +274,7 @@ Bundle package `bar` that depends on `foo`.
   bar-bundle/common.sh
   bar-bundle/compile.sh
   bar-bundle/configure.sh
-  bar-bundle/opam-full-2.1.0-rc2.tar.gz
+  bar-bundle/opam-full-2.1.4.tar.gz
   bar-bundle/repo/
   bar-bundle/repo/archives/
   bar-bundle/repo/archives/bar.1/
@@ -352,6 +356,8 @@ Cleaning up
 Bundle package `bar` that depends on `foo` with self-extracting script.
 
   $ opam-bundle bar.1 --self --repository ./REPO --ocaml=4.14.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  OCaml version is set to 4.14.0.
+  No opam version selected, will use 2.1.4.
   No environment specified, will use the following for package resolution (based on the host system):
     - arch = $ARCH
     - os = $OS

--- a/tests/stub/env.t
+++ b/tests/stub/env.t
@@ -7,8 +7,6 @@ Repo initial setup with three packages `foo`, `bar`, and `baz`, with specific av
   $ export OPAMROOT=$PWD/OPAMROOT
   $ export OPAMSTATUSLINE=never
   $ export OPAMVERBOSE=-1
-  $ opam --version
-  2.1.4
 Stub executable
   $ cat > compile << EOF
   > #!/bin/sh

--- a/tests/stub/env.t
+++ b/tests/stub/env.t
@@ -162,6 +162,8 @@ Bundle package `baz`, without '--environment' option. That should lookup current
 are available on linux os (`foo` not included).
 
   $ opam-bundle baz --repository ./REPO --ocaml=4.14.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  OCaml version is set to 4.14.0.
+  No opam version selected, will use 2.1.4.
   No environment specified, will use the following for package resolution (based on the host system):
     - arch = $ARCH
     - os = $OS
@@ -196,7 +198,7 @@ are available on linux os (`foo` not included).
   baz-bundle/common.sh
   baz-bundle/compile.sh
   baz-bundle/configure.sh
-  baz-bundle/opam-full-2.1.0-rc2.tar.gz
+  baz-bundle/opam-full-2.1.4.tar.gz
   baz-bundle/repo/
   baz-bundle/repo/archives/
   baz-bundle/repo/archives/bar.1/
@@ -241,6 +243,8 @@ Bundle package `baz`, with os="cygwin" constraint specified in '--environment' o
 are available on cygwin os (`bar` not included).
 
   $ opam-bundle baz --environment os="cygwin" --repository ./REPO --ocaml=4.14.0 -y 2>&1
+  OCaml version is set to 4.14.0.
+  No opam version selected, will use 2.1.4.
   
   <><> Initialising repositories ><><><><><><><><><><><><><><><><><><><><><><><><>
   [home] Initialised
@@ -271,7 +275,7 @@ are available on cygwin os (`bar` not included).
   baz-bundle/common.sh
   baz-bundle/compile.sh
   baz-bundle/configure.sh
-  baz-bundle/opam-full-2.1.0-rc2.tar.gz
+  baz-bundle/opam-full-2.1.4.tar.gz
   baz-bundle/repo/
   baz-bundle/repo/archives/
   baz-bundle/repo/archives/baz.1/
@@ -316,6 +320,8 @@ Bundle package `baz`, with empty constraint specified in '--environment' option.
 all dependencies.
 
   $ opam-bundle baz --environment --repository ./REPO --ocaml=4.14.0 -y 2>&1
+  OCaml version is set to 4.14.0.
+  No opam version selected, will use 2.1.4.
   [NOTE] Empty environment
   
   <><> Initialising repositories ><><><><><><><><><><><><><><><><><><><><><><><><>
@@ -348,7 +354,7 @@ all dependencies.
   baz-bundle/common.sh
   baz-bundle/compile.sh
   baz-bundle/configure.sh
-  baz-bundle/opam-full-2.1.0-rc2.tar.gz
+  baz-bundle/opam-full-2.1.4.tar.gz
   baz-bundle/repo/
   baz-bundle/repo/archives/
   baz-bundle/repo/archives/bar.1/
@@ -397,6 +403,8 @@ Trying bundle package `bar` on cygwin. That will fail, since this package isn't 
 
 
   $ opam-bundle bar --environment os="cygwin" --repository ./REPO --ocaml=4.14.0 -y 2>&1
+  OCaml version is set to 4.14.0.
+  No opam version selected, will use 2.1.4.
   
   <><> Initialising repositories ><><><><><><><><><><><><><><><><><><><><><><><><>
   [home] Initialised

--- a/tests/stub/packages.t
+++ b/tests/stub/packages.t
@@ -6,8 +6,6 @@ Every package used is a stub package.
   $ export OPAMROOT=$PWD/OPAMROOT
   $ export OPAMSTATUSLINE=never
   $ export OPAMVERBOSE=-1
-  $ opam --version
-  2.1.4
 Different version of one stub executable
   $ cat > compile << EOF
   > #!/bin/sh
@@ -555,7 +553,7 @@ wrapper.
   
   <><> Getting all archives <><><><><><><><><><><><><><><><><><><><><><><><><><><>
   [WARNING] Extra source repo of foo.4 from file://./REPO/repo had no recorded checksum: adding md5=$HASH
-
+  
   <><> Getting bootstrap packages <><><><><><><><><><><><><><><><><><><><><><><><>
   
   <><> Building bundle ><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
@@ -567,7 +565,7 @@ wrapper.
   bar-bundle/common.sh
   bar-bundle/compile.sh
   bar-bundle/configure.sh
-  bar-bundle/opam-full-2.1.0-rc2.tar.gz
+  bar-bundle/opam-full-2.1.4.tar.gz
   bar-bundle/repo/
   bar-bundle/repo/archives/
   bar-bundle/repo/archives/bar.3/

--- a/tests/stub/packages.t
+++ b/tests/stub/packages.t
@@ -262,6 +262,8 @@ Running opam-bundle with sanitized output that contains replaced platform specif
 Bundle single package `bar` of version 2. That implies installation of its dependency `foo` with constraint "<=2".
 
   $ opam-bundle bar.2 --repository ./REPO --ocaml=4.14.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  OCaml version is set to 4.14.0.
+  No opam version selected, will use 2.1.4.
   No environment specified, will use the following for package resolution (based on the host system):
     - arch = $ARCH
     - os = $OS
@@ -296,7 +298,7 @@ Bundle single package `bar` of version 2. That implies installation of its depen
   bar-bundle/common.sh
   bar-bundle/compile.sh
   bar-bundle/configure.sh
-  bar-bundle/opam-full-2.1.0-rc2.tar.gz
+  bar-bundle/opam-full-2.1.4.tar.gz
   bar-bundle/repo/
   bar-bundle/repo/archives/
   bar-bundle/repo/archives/bar.2/
@@ -388,6 +390,8 @@ Bundle two packages `bar` and `foo>2`. Forcing constraint on `foo` implies insta
 Since `foo` was specified as argument to `opam-bundle` it installs additionally `foo` wrapper.
 
   $ opam-bundle bar 'foo>2' --repository ./REPO --ocaml=4.14.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  OCaml version is set to 4.14.0.
+  No opam version selected, will use 2.1.4.
   No environment specified, will use the following for package resolution (based on the host system):
     - arch = $ARCH
     - os = $OS
@@ -422,7 +426,7 @@ Since `foo` was specified as argument to `opam-bundle` it installs additionally 
   bar-bundle/common.sh
   bar-bundle/compile.sh
   bar-bundle/configure.sh
-  bar-bundle/opam-full-2.1.0-rc2.tar.gz
+  bar-bundle/opam-full-2.1.4.tar.gz
   bar-bundle/repo/
   bar-bundle/repo/archives/
   bar-bundle/repo/archives/bar.3/
@@ -521,7 +525,9 @@ has extra-source (opam-bundle archive 0.4) that should be also bundled. Forcing 
 installation of `bar.3`. Since `foo` was specified as argument to `opam-bundle` it installs additionally `foo`
 wrapper.
 
-  $ opam-bundle bar 'foo@foo.4' --repository ./REPO --ocaml=4.14.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/;s/md5=.*/md5=$HASH/'
+  $ opam-bundle bar 'foo@foo.4' --repository ./REPO --ocaml=4.14.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/;s/md5=.*/md5=$HASH/' | sed 's/.* No such file or directory/mv error/g'
+  OCaml version is set to 4.14.0.
+  No opam version selected, will use 2.1.4.
   No environment specified, will use the following for package resolution (based on the host system):
     - arch = $ARCH
     - os = $OS
@@ -549,7 +555,7 @@ wrapper.
   
   <><> Getting all archives <><><><><><><><><><><><><><><><><><><><><><><><><><><>
   [WARNING] Extra source repo of foo.4 from file://./REPO/repo had no recorded checksum: adding md5=$HASH
-  
+
   <><> Getting bootstrap packages <><><><><><><><><><><><><><><><><><><><><><><><>
   
   <><> Building bundle ><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
@@ -657,6 +663,8 @@ wrapper.
 Trying to bundle two packages `bar.3` and `foo.1`. This should fail, because those versions are not compatible.
 
   $ opam-bundle bar.3 foo.1 --repository ./REPO --ocaml=4.14.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  OCaml version is set to 4.14.0.
+  No opam version selected, will use 2.1.4.
   No environment specified, will use the following for package resolution (based on the host system):
     - arch = $ARCH
     - os = $OS

--- a/tests/stub/repos.t
+++ b/tests/stub/repos.t
@@ -6,8 +6,6 @@ Every package used is a stub package.
   $ export OPAMROOT=$PWD/OPAMROOT
   $ export OPAMSTATUSLINE=never
   $ export OPAMVERBOSE=-1
-  $ opam --version
-  2.1.4
 Stub executable
   $ cat > compile << EOF
   > #!/bin/sh

--- a/tests/stub/repos.t
+++ b/tests/stub/repos.t
@@ -273,6 +273,8 @@ Bundle package foo with and specifyng two repositories with `ocaml.4.12` and sec
 only `ocaml.4.14` packages. We are forcing here to use 4.12 from second switch.
 
   $ opam-bundle foo --repository ./REPO1 --repository ./REPO3 --ocaml=4.12.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  OCaml version is set to 4.12.0.
+  No opam version selected, will use 2.1.4.
   No environment specified, will use the following for package resolution (based on the host system):
     - arch = $ARCH
     - os = $OS
@@ -312,6 +314,8 @@ Bundle packages foo and bar with specifying three repositories with `foo` and se
 package and third containing required ocaml-config.2. We are forcing here to use 4.13 from switch.
 
   $ opam-bundle foo bar --repository ./REPO1 --repository ./REPO2 --repository ./REPO3 --ocaml=4.13.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  OCaml version is set to 4.13.0.
+  No opam version selected, will use 2.1.4.
   No environment specified, will use the following for package resolution (based on the host system):
     - arch = $ARCH
     - os = $OS
@@ -352,6 +356,8 @@ package and third containing required ocaml-config.2. We are forcing here to use
 Trying bundle foo package with a repository that hasn't required package (ocaml-config). That should fail.
 
   $ opam-bundle foo --repository ./REPO1 --ocaml=4.14.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  OCaml version is set to 4.14.0.
+  No opam version selected, will use 2.1.4.
   No environment specified, will use the following for package resolution (based on the host system):
     - arch = $ARCH
     - os = $OS
@@ -377,6 +383,8 @@ Trying bundle foo package with a repository that hasn't required package (ocaml-
 Trying bundle foo package with a repositories that hasn't required ocaml version. That should fail.
 
   $ opam-bundle foo --repository ./REPO1 --repository ./REPO3 --ocaml=4.13.0 -y 2>&1 | sed 's/arch =.*/arch = $ARCH/;s/os =.*/os = $OS/;s/os-distribution =.*/os-distribution = $OSDISTRIB/;s/os-version =.*/os-version = $OSVERSION/;s/os-family =.*/os-family = $OSFAMILLY/'
+  OCaml version is set to 4.13.0.
+  No opam version selected, will use 2.1.4.
   No environment specified, will use the following for package resolution (based on the host system):
     - arch = $ARCH
     - os = $OS


### PR DESCRIPTION
This PR bumps up latest supported bootstrapped opam's version. Additionally, it provides some bindings to a concrete version of opam:  
- 2.0 -> 2.0.10 
- 2.1 -> 2.1.4